### PR TITLE
Auto-attack adjustments (damage, behaviour), HP/MP/TP regen following new rules

### DIFF
--- a/src/servers/Server_Common/ExdData.cpp
+++ b/src/servers/Server_Common/ExdData.cpp
@@ -425,6 +425,7 @@ boost::shared_ptr< Core::Data::ItemInfo >
       info->is_hqable = getField< bool >( row, 20 );
       info->model_primary = getField< uint64_t >( row, 45 );
       info->model_secondary = getField< uint64_t >( row, 46 );
+      info->physical_damage = getField< uint16_t >( row, 49 );
       info->delayMs = getField< uint16_t >( row, 51 );
       info->is_unique = getField< int16_t >( row, 64 ) != 0 ? true : false;
       info->is_untradeable = getField< uint8_t >( row, 65 ) != 0 ? true : false;

--- a/src/servers/Server_Common/ExdData.h
+++ b/src/servers/Server_Common/ExdData.h
@@ -201,20 +201,21 @@ namespace Core {
       struct ItemInfo
       {
          uint32_t id;
-         std::string name; //0
-         uint16_t item_level;//11
-         uint8_t required_level;//12
-         uint32_t stack_size;//19
-         uint16_t unknown_category;//15
-         uint16_t ui_category;//17
-         bool is_hqable;//20
-         uint64_t model_primary;//28
-         uint64_t model_secondary;//29
-         uint32_t class_job_requirement;//58
-         uint16_t delayMs; //59
-         bool is_unique;//72
-         bool is_untradeable;//73
-         uint32_t class_job_index;//86
+         std::string name;                //0
+         uint16_t item_level;             //11
+         uint8_t required_level;          //12
+         uint16_t unknown_category;       //15
+         uint16_t ui_category;            //17
+         uint32_t stack_size;             //19
+         bool is_hqable;                  //20
+         uint64_t model_primary;          //28
+         uint64_t model_secondary;        //29
+         uint16_t physical_damage;        //49
+         uint32_t class_job_requirement;  //58
+         uint16_t delayMs;                //59
+         bool is_unique;                  //72
+         bool is_untradeable;             //73
+         uint32_t class_job_index;        //86
       };
 
       struct ActionInfo

--- a/src/servers/Server_Zone/Item.cpp
+++ b/src/servers/Server_Zone/Item.cpp
@@ -26,6 +26,8 @@ Core::Item::Item( uint64_t uId, uint32_t catalogId, uint64_t model1, uint64_t mo
 {
    auto itemInfo = g_exdData.getItemInfo( catalogId );
    m_delayMs = itemInfo->delayMs;
+   m_physicalDmg = itemInfo->physical_damage;
+   m_autoAttackDmg = float(m_physicalDmg * m_delayMs) / 3000;
 }
 
 Core::Item::~Item()
@@ -33,9 +35,19 @@ Core::Item::~Item()
 
 }
 
+float Core::Item::getAutoAttackDmg() const
+{
+   return m_autoAttackDmg;
+}
+
 uint16_t Core::Item::getDelay() const
 {
    return m_delayMs;
+}
+
+uint16_t Core::Item::getPhysicalDmg() const
+{
+   return m_physicalDmg;
 }
 
 uint32_t Core::Item::getId() const

--- a/src/servers/Server_Zone/Item.cpp
+++ b/src/servers/Server_Zone/Item.cpp
@@ -27,7 +27,7 @@ Core::Item::Item( uint64_t uId, uint32_t catalogId, uint64_t model1, uint64_t mo
    auto itemInfo = g_exdData.getItemInfo( catalogId );
    m_delayMs = itemInfo->delayMs;
    m_physicalDmg = itemInfo->physical_damage;
-   m_autoAttackDmg = float(m_physicalDmg * m_delayMs) / 3000;
+   m_autoAttackDmg = float( m_physicalDmg * m_delayMs ) / 3000;
 }
 
 Core::Item::~Item()

--- a/src/servers/Server_Zone/Item.h
+++ b/src/servers/Server_Zone/Item.h
@@ -39,7 +39,12 @@ public:
    bool isHq() const;
 
    void setHq( bool isHq );
+
    uint16_t getDelay() const;
+
+   uint16_t getPhysicalDmg() const;
+
+   float getAutoAttackDmg() const;
 
 
 protected:
@@ -58,6 +63,8 @@ protected:
    bool                    m_isHq;
 
    uint16_t                m_delayMs;
+   uint16_t                m_physicalDmg;
+   float                   m_autoAttackDmg;
 
 };
 

--- a/src/servers/Server_Zone/PacketHandlers.cpp
+++ b/src/servers/Server_Zone/PacketHandlers.cpp
@@ -798,10 +798,13 @@ void Core::Network::GameConnection::actionHandler( Core::Network::Packets::GameP
    {
    case 0x01:
    {
-      if( param11 == 1 )
-         pPlayer->setStance( Entity::Actor::Stance::Active );
+      if (param11 == 1)
+         pPlayer->setStance(Entity::Actor::Stance::Active);
       else
-         pPlayer->setStance( Entity::Actor::Stance::Passive );
+      {
+         pPlayer->setStance(Entity::Actor::Stance::Passive);
+         pPlayer->setAutoattack(false);
+      }
 
       pPlayer->sendToInRangeSet( ActorControlPacket142( pPlayer->getId(), 0, param11, 1 ) );
 
@@ -810,7 +813,10 @@ void Core::Network::GameConnection::actionHandler( Core::Network::Packets::GameP
    case 0x02:
    {
       if (param11 == 1)
+      {
          pPlayer->setAutoattack( true );
+         pPlayer->setStance(Entity::Actor::Stance::Active);
+      }
       else
          pPlayer->setAutoattack( false );
 

--- a/src/servers/Server_Zone/PacketHandlers.cpp
+++ b/src/servers/Server_Zone/PacketHandlers.cpp
@@ -796,31 +796,31 @@ void Core::Network::GameConnection::actionHandler( Core::Network::Packets::GameP
 
    switch( commandId )
    {
-   case 0x01:
+   case 0x01:  // Toggle sheathe
    {
-      if (param11 == 1)
-         pPlayer->setStance(Entity::Actor::Stance::Active);
+      if ( param11 == 1 )
+         pPlayer->setStance( Entity::Actor::Stance::Active );
       else
       {
-         pPlayer->setStance(Entity::Actor::Stance::Passive);
-         pPlayer->setAutoattack(false);
+         pPlayer->setStance( Entity::Actor::Stance::Passive );
+         pPlayer->setAutoattack( false );
       }
 
       pPlayer->sendToInRangeSet( ActorControlPacket142( pPlayer->getId(), 0, param11, 1 ) );
 
       break;
    }
-   case 0x02:
+   case 0x02:  // Toggle auto-attack
    {
-      if (param11 == 1)
+      if ( param11 == 1 )
       {
          pPlayer->setAutoattack( true );
-         pPlayer->setStance(Entity::Actor::Stance::Active);
+         pPlayer->setStance( Entity::Actor::Stance::Active );
       }
       else
          pPlayer->setAutoattack( false );
 
-      pPlayer->sendToInRangeSet(ActorControlPacket142(pPlayer->getId(), 1, param11, 1));
+      pPlayer->sendToInRangeSet( ActorControlPacket142( pPlayer->getId(), 1, param11, 1 ) );
 
       break;
    }

--- a/src/servers/Server_Zone/Player.cpp
+++ b/src/servers/Server_Zone/Player.cpp
@@ -615,7 +615,7 @@ void Core::Entity::Player::gainExp( uint32_t amount )
 
    queuePacket( ActorControlPacket143( getId(), GainExpMsg, static_cast< uint8_t >( getClass() ), amount ) );
 
-   if( level >= 60 ) // temporary fix for leveling over levelcap
+   if( level >= 70 ) // temporary fix for leveling over levelcap
    {
       queuePacket( ActorControlPacket143( getId(), UpdateUiExp, static_cast< uint8_t >( getClass() ), amount ) );
       return;
@@ -1085,7 +1085,9 @@ void Core::Entity::Player::update( int64_t currTime )
             if( isAutoattackOn() && 
                 actor->getId() == m_targetId &&
                 actor->isAlive() &&
-                mainWeap )
+                mainWeap &&
+                m_currentStance == Entity::Actor::Stance::Active
+               )
             {
                // default autoattack range
                // TODO make this dependant on bnpc size
@@ -1430,11 +1432,13 @@ void Core::Entity::Player::setIsLogin( bool bIsLogin )
 void Core::Entity::Player::autoAttack( ActorPtr pTarget )
 {
 
+   auto mainWeap = m_pInventory->getItemAt(Inventory::GearSet0, Inventory::EquipSlot::MainHand);
+
    pTarget->onActionHostile( shared_from_this() );
    //uint64_t tick = Util::getTimeMs();
-
    //srand(static_cast< uint32_t >(tick));
-   uint32_t damage = 10 + rand() % 12;
+
+   uint32_t damage = mainWeap->getAutoAttackDmg() + rand() % 12;   
    uint32_t variation = 0 + rand() % 3;
 
    if( getClass() == 5 || getClass() == 23 || getClass() == 31 )

--- a/src/servers/Server_Zone/PlayerEvent.cpp
+++ b/src/servers/Server_Zone/PlayerEvent.cpp
@@ -263,12 +263,14 @@ void Core::Entity::Player::onTick()
       return;
 
    int32_t addHp = getMaxHp() * 0.1f + 1;
-   int32_t addMp = 8 * 0.1f + 1;
+   int32_t addMp = getMaxMp() * 0.06f + 1;
+   int32_t addTp = 100;
 
    if( !m_actorIdTohateSlotMap.empty() )
    {
       addHp = getMaxHp() * 0.01f + 1;
-      addMp = getMaxHp() * 0.01f + 1;
+      addMp = getMaxHp() * 0.02f + 1;
+      addTp = 60;
    }
 
    if( m_hp < getMaxHp() )
@@ -295,7 +297,6 @@ void Core::Entity::Player::onTick()
 
    if( m_tp < 1000 )
    {
-      int32_t addTp = 100;
       if( m_tp + addTp < 1000 )
          m_tp += addTp;
       else


### PR DESCRIPTION
Auto-attack was slightly off (attacking while unsheathed etc).
Worked on auto-attack damage as well.
Should fix an issue mentioned in #20 (MP regen), as well as calculating the correct refresh values for in and out of combat for HP, MP and TP.