### PR TITLE
Sorted out power/param property of status (partially)

### DIFF
--- a/bin/scripts/chai/skill/skillDef_3.chai
+++ b/bin/scripts/chai/skill/skillDef_3.chai
@@ -10,7 +10,7 @@ class skillDef_3Def
 
     def onFinish( player, target )
     {
-        player.addStatusEffectById(50, 20000, 3791585310);
+        player.addStatusEffectById(50, 20000, 30, 65505);
     }
 
 };

--- a/bin/scripts/chai/skill/skillDef_3.chai
+++ b/bin/scripts/chai/skill/skillDef_3.chai
@@ -10,7 +10,7 @@ class skillDef_3Def
 
     def onFinish( player, target )
     {
-        player.addStatusEffectById(50, 20000, 30, 65505);
+        player.addStatusEffectById(50, 20000, 30);
     }
 
 };

--- a/src/servers/Server_Common/ServerPacketDef.h
+++ b/src/servers/Server_Common/ServerPacketDef.h
@@ -339,8 +339,8 @@ struct FFXIVIpcAddStatusEffect : FFXIVIpcBasePacket<AddStatusEffect>
    uint8_t effect_index; // which position do i display this
    uint8_t unknown3;
    uint16_t effect_id;
-   uint16_t unkpower1;
-   uint16_t unkpower2;
+   uint16_t param;
+   uint16_t unknown5;    // Sort this out (old right half of power/param property)
    float duration;
    uint32_t actor_id1;
    uint8_t unknown4[52];

--- a/src/servers/Server_Common/ServerPacketDef.h
+++ b/src/servers/Server_Common/ServerPacketDef.h
@@ -339,7 +339,8 @@ struct FFXIVIpcAddStatusEffect : FFXIVIpcBasePacket<AddStatusEffect>
    uint8_t effect_index; // which position do i display this
    uint8_t unknown3;
    uint16_t effect_id;
-   uint32_t power;
+   uint16_t unkpower1;
+   uint16_t unkpower2;
    float duration;
    uint32_t actor_id1;
    uint8_t unknown4[52];

--- a/src/servers/Server_Zone/Actor.cpp
+++ b/src/servers/Server_Zone/Actor.cpp
@@ -605,10 +605,11 @@ void Core::Entity::Actor::addStatusEffect( StatusEffect::StatusEffectPtr pEffect
 }
 
 /*! \param StatusEffectPtr to be applied to the actor */
-void Core::Entity::Actor::addStatusEffectById( int32_t id, int32_t duration, uint32_t power )
+void Core::Entity::Actor::addStatusEffectById( int32_t id, int32_t duration, uint16_t power, uint16_t power_2 )
 {
    StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, shared_from_this(), shared_from_this(), duration, 3000 ) );
    effect->setPower( power );
+   effect->setPower_2( power_2 );
    addStatusEffect( effect );
 }
 

--- a/src/servers/Server_Zone/Actor.cpp
+++ b/src/servers/Server_Zone/Actor.cpp
@@ -605,11 +605,10 @@ void Core::Entity::Actor::addStatusEffect( StatusEffect::StatusEffectPtr pEffect
 }
 
 /*! \param StatusEffectPtr to be applied to the actor */
-void Core::Entity::Actor::addStatusEffectById( int32_t id, int32_t duration, uint16_t power, uint16_t power_2 )
+void Core::Entity::Actor::addStatusEffectById( int32_t id, int32_t duration, uint16_t param )
 {
    StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, shared_from_this(), shared_from_this(), duration, 3000 ) );
-   effect->setPower( power );
-   effect->setPower_2( power_2 );
+   effect->setParam( param );
    addStatusEffect( effect );
 }
 

--- a/src/servers/Server_Zone/Actor.h
+++ b/src/servers/Server_Zone/Actor.h
@@ -290,7 +290,7 @@ public:
    void addStatusEffect( StatusEffect::StatusEffectPtr pEffect );
 
    // add a status effect by id
-   void addStatusEffectById( int32_t id, int32_t duration, uint32_t power = 0 );
+   void addStatusEffectById( int32_t id, int32_t duration, uint16_t power = 0, uint16_t power_2 = 0 );
 
    // TODO: Why did i even declare them publicly here?!
    std::set< ActorPtr >            m_inRangeActors;

--- a/src/servers/Server_Zone/Actor.h
+++ b/src/servers/Server_Zone/Actor.h
@@ -290,7 +290,7 @@ public:
    void addStatusEffect( StatusEffect::StatusEffectPtr pEffect );
 
    // add a status effect by id
-   void addStatusEffectById( int32_t id, int32_t duration, uint16_t power = 0, uint16_t power_2 = 0 );
+   void addStatusEffectById( int32_t id, int32_t duration, uint16_t param = 0 );
 
    // TODO: Why did i even declare them publicly here?!
    std::set< ActorPtr >            m_inRangeActors;

--- a/src/servers/Server_Zone/GameCommandHandler.cpp
+++ b/src/servers/Server_Zone/GameCommandHandler.cpp
@@ -363,10 +363,15 @@ void Core::GameCommandHandler::add( char * data, Core::Entity::PlayerPtr pPlayer
    {
       int32_t id;
       int32_t duration;
+      uint16_t power;
 
-      sscanf( params.c_str(), "%d %d", &id, &duration );
+      uint16_t power_2;
+
+      sscanf( params.c_str(), "%d %d %hd %hd", &id, &duration, &power, &power_2 );
 
       StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, pPlayer, pPlayer, duration, 3000 ) );
+      effect->setPower( power );
+      effect->setPower_2( power_2 );
       pPlayer->addStatusEffect( effect );
    }
    else if( subCommand == "spawn" )

--- a/src/servers/Server_Zone/GameCommandHandler.cpp
+++ b/src/servers/Server_Zone/GameCommandHandler.cpp
@@ -363,15 +363,13 @@ void Core::GameCommandHandler::add( char * data, Core::Entity::PlayerPtr pPlayer
    {
       int32_t id;
       int32_t duration;
-      uint16_t power;
+      uint16_t param;
 
-      uint16_t power_2;
-
-      sscanf( params.c_str(), "%d %d %hd %hd", &id, &duration, &power, &power_2 );
+      sscanf( params.c_str(), "%d %d %hd", &id, &duration, &param );
 
       StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, pPlayer, pPlayer, duration, 3000 ) );
-      effect->setPower( power );
-      effect->setPower_2( power_2 );
+      effect->setParam( param );
+
       pPlayer->addStatusEffect( effect );
    }
    else if( subCommand == "spawn" )

--- a/src/servers/Server_Zone/StatusEffect.cpp
+++ b/src/servers/Server_Zone/StatusEffect.cpp
@@ -67,14 +67,9 @@ uint32_t Core::StatusEffect::StatusEffect::getTargetActorId() const
    return m_targetActor->getId();
 }
 
-uint16_t Core::StatusEffect::StatusEffect::getPower() const
+uint16_t Core::StatusEffect::StatusEffect::getParam() const
 {
-   return m_unkpower1;
-}
-
-uint16_t Core::StatusEffect::StatusEffect::getPower_2() const
-{
-   return m_unkpower2;
+   return m_param;
 }
 
 void Core::StatusEffect::StatusEffect::applyStatus()
@@ -139,14 +134,9 @@ void Core::StatusEffect::StatusEffect::setLastTick( uint64_t lastTick )
    m_lastTick = lastTick;
 }
 
-void Core::StatusEffect::StatusEffect::setPower( uint16_t power )
+void Core::StatusEffect::StatusEffect::setParam( uint16_t param )
 {
-   m_unkpower1 = power;
-}
-
-void Core::StatusEffect::StatusEffect::setPower_2( uint16_t power )
-{
-   m_unkpower2 = power;
+   m_param = param;
 }
 
 const std::string& Core::StatusEffect::StatusEffect::getName() const

--- a/src/servers/Server_Zone/StatusEffect.cpp
+++ b/src/servers/Server_Zone/StatusEffect.cpp
@@ -67,9 +67,14 @@ uint32_t Core::StatusEffect::StatusEffect::getTargetActorId() const
    return m_targetActor->getId();
 }
 
-uint32_t Core::StatusEffect::StatusEffect::getPower() const
+uint16_t Core::StatusEffect::StatusEffect::getPower() const
 {
-   return m_power;
+   return m_unkpower1;
+}
+
+uint16_t Core::StatusEffect::StatusEffect::getPower_2() const
+{
+   return m_unkpower2;
 }
 
 void Core::StatusEffect::StatusEffect::applyStatus()
@@ -134,11 +139,15 @@ void Core::StatusEffect::StatusEffect::setLastTick( uint64_t lastTick )
    m_lastTick = lastTick;
 }
 
-void Core::StatusEffect::StatusEffect::setPower( uint32_t power )
+void Core::StatusEffect::StatusEffect::setPower( uint16_t power )
 {
-   m_power = power;
+   m_unkpower1 = power;
 }
 
+void Core::StatusEffect::StatusEffect::setPower_2( uint16_t power )
+{
+   m_unkpower2 = power;
+}
 
 const std::string& Core::StatusEffect::StatusEffect::getName() const
 {

--- a/src/servers/Server_Zone/StatusEffect.h
+++ b/src/servers/Server_Zone/StatusEffect.h
@@ -30,9 +30,11 @@ public:
    uint32_t getTargetActorId() const;
    uint64_t getLastTickMs() const;
    uint64_t getStartTimeMs() const;
-   uint32_t getPower() const;
+   uint16_t getPower() const;
+   uint16_t getPower_2() const;
    void setLastTick( uint64_t lastTick );
-   void setPower( uint32_t power );
+   void setPower( uint16_t power );
+   void setPower_2( uint16_t power );
    const std::string& getName() const;
 
 private:
@@ -43,7 +45,8 @@ private:
    uint64_t m_startTime;
    uint32_t m_tickRate;
    uint64_t m_lastTick;
-   uint32_t m_power;  //Figure out what this actually is supposed to be
+   uint16_t m_unkpower1;
+   uint16_t m_unkpower2;  //Figure out what this actually is supposed to be
    std::string m_name;
 
 };

--- a/src/servers/Server_Zone/StatusEffect.h
+++ b/src/servers/Server_Zone/StatusEffect.h
@@ -30,11 +30,9 @@ public:
    uint32_t getTargetActorId() const;
    uint64_t getLastTickMs() const;
    uint64_t getStartTimeMs() const;
-   uint16_t getPower() const;
-   uint16_t getPower_2() const;
+   uint16_t getParam() const;
    void setLastTick( uint64_t lastTick );
-   void setPower( uint16_t power );
-   void setPower_2( uint16_t power );
+   void setParam( uint16_t param );
    const std::string& getName() const;
 
 private:
@@ -45,8 +43,7 @@ private:
    uint64_t m_startTime;
    uint32_t m_tickRate;
    uint64_t m_lastTick;
-   uint16_t m_unkpower1;
-   uint16_t m_unkpower2;  //Figure out what this actually is supposed to be
+   uint16_t m_param;
    std::string m_name;
 
 };

--- a/src/servers/Server_Zone/StatusEffectContainer.cpp
+++ b/src/servers/Server_Zone/StatusEffectContainer.cpp
@@ -69,7 +69,8 @@ void Core::StatusEffect::StatusEffectContainer::addStatusEffect( StatusEffectPtr
    statusEffectAdd.data().max_mp = m_pOwner->getMaxMp();
    statusEffectAdd.data().max_something = 1;
     //statusEffectAdd.data().unknown2 = 28;
-   statusEffectAdd.data().power = pEffect->getPower();
+   statusEffectAdd.data().unkpower1 = pEffect->getPower();
+   statusEffectAdd.data().unkpower2 = pEffect->getPower_2();
 
    bool sendToSelf = m_pOwner->isPlayer() ? true : false;
    m_pOwner->sendToInRangeSet( statusEffectAdd, sendToSelf );

--- a/src/servers/Server_Zone/StatusEffectContainer.cpp
+++ b/src/servers/Server_Zone/StatusEffectContainer.cpp
@@ -69,8 +69,7 @@ void Core::StatusEffect::StatusEffectContainer::addStatusEffect( StatusEffectPtr
    statusEffectAdd.data().max_mp = m_pOwner->getMaxMp();
    statusEffectAdd.data().max_something = 1;
     //statusEffectAdd.data().unknown2 = 28;
-   statusEffectAdd.data().unkpower1 = pEffect->getPower();
-   statusEffectAdd.data().unkpower2 = pEffect->getPower_2();
+   statusEffectAdd.data().param = pEffect->getParam();
 
    bool sendToSelf = m_pOwner->isPlayer() ? true : false;
    m_pOwner->sendToInRangeSet( statusEffectAdd, sendToSelf );


### PR DESCRIPTION
We were reading power from the packet as a 32bit value, but apparently it's 2 values of 16-bit.

In the case of sprint, we gave it a value of "3791585310", which would then overflow (due to sign). 
The values now make a little more sense now that they're split.
The status function has also been extended further to allow the new param property.
Power parameter has been renamed as param, due to how other status may use this property not as a potency modifier but as a parameter for models, etc.

There are a few things that we learned from this, such as how the Transfiguration status works.
The first parameter (param) refers to the index found in transformation.exh, and applies scaling, speed and other properties (including UI as well) client-side. 
Curiously, some of the trial/raid boss models are here - it's possible that this is also used for the phase transitions and so on.
Example of usage:  

> @add status 705 5000 20


We still have no idea as to what the second parameter is for. 

Big thanks to @amibu01 and everyone in the discord!

