### PR TITLE
Initial attempt to fix 64bit build

### DIFF
--- a/src/servers/Server_Common/CMakeLists.txt
+++ b/src/servers/Server_Common/CMakeLists.txt
@@ -8,7 +8,7 @@ if(UNIX)
   include_directories("/usr/include/mysql/")
   message(STATUS "Setting GCC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  
+
   find_package(Boost ${SAPPHIRE_BOOST_VER} COMPONENTS log log_setup thread date_time filesystem system)
   if(Boost_FOUND)
     set(BOOST_LIBRARY_DIR ${Boost_LIBRARY_DIR})
@@ -26,6 +26,7 @@ else()
   message(STATUS "Setting MSVC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/${SAPPHIRE_BOOST_FOLDER_NAME})
     message(STATUS "Using boost in /libraries/external")

--- a/src/servers/Server_Lobby/CMakeLists.txt
+++ b/src/servers/Server_Lobby/CMakeLists.txt
@@ -16,7 +16,7 @@ if(UNIX)
   include_directories("/usr/include/mysql/")
   message(STATUS "Setting GCC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  
+
   find_package(Boost ${SAPPHIRE_BOOST_VER} COMPONENTS log log_setup thread date_time filesystem system)
   if(Boost_FOUND)
     set(BOOST_LIBRARY_DIR ${Boost_LIBRARY_DIR})
@@ -36,6 +36,7 @@ else()
   message(STATUS "Setting MSVC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/${SAPPHIRE_BOOST_FOLDER_NAME})
     message(STATUS "Using boost in /libraries/external")

--- a/src/servers/Server_Lobby/blowfish.cpp
+++ b/src/servers/Server_Lobby/blowfish.cpp
@@ -104,7 +104,7 @@ void BlowFish::initialize (BYTE key[], int32_t keybytes)
 
 
   int32_t v10 = keybytes;
-  int32_t v9 = (uintptr_t)key;
+  uintptr_t v9 = (uintptr_t)key;
   int32_t v8 = 0;
   int32_t v11 = 0;
   do {

--- a/src/servers/Server_REST/CMakeLists.txt
+++ b/src/servers/Server_REST/CMakeLists.txt
@@ -16,7 +16,7 @@ if(UNIX)
   include_directories("/usr/include/mysql/")
   message(STATUS "Setting GCC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  
+
   find_package(Boost ${SAPPHIRE_BOOST_VER} COMPONENTS log log_setup thread date_time filesystem system)
   if(Boost_FOUND)
     set(BOOST_LIBRARY_DIR ${Boost_LIBRARY_DIR})
@@ -36,6 +36,7 @@ else()
   message(STATUS "Setting MSVC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/${SAPPHIRE_BOOST_FOLDER_NAME})
     message(STATUS "Using boost in /src/lib")

--- a/src/servers/Server_Zone/CMakeLists.txt
+++ b/src/servers/Server_Zone/CMakeLists.txt
@@ -16,7 +16,7 @@ if(UNIX)
   include_directories("/usr/include/mysql/")
   message(STATUS "Setting GCC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  
+
   find_package(Boost ${SAPPHIRE_BOOST_VER} COMPONENTS log log_setup thread date_time filesystem system)
   if(Boost_FOUND)
     set(BOOST_LIBRARY_DIR ${Boost_LIBRARY_DIR})
@@ -36,6 +36,7 @@ else()
   message(STATUS "Setting MSVC flags")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/${SAPPHIRE_BOOST_FOLDER_NAME})
     message(STATUS "Using boost in /libraries/external")


### PR DESCRIPTION
## Summary
- Add /bigobj flag.
- Fix segfault while deriving a key for lobby encryption.

## Notes
- GNU toolchain is not tested for 64bit. Use MSVC for now.
- Even with this PR, it's still quite a pain in the ass to build x64, basically you need to:
    - Build 64bit version of boost and hope CMake can find them.
    - Build 64bit version of zlib and MySQL connector(C version) lib and link against it.
        - Also don't forget to copy 64bit version of dll to bin directory.
    - Use Win64 version of generator **AND** force 64bit version of toolset.
        - Oh, you forgot to clean CMakeCache and CMakeFiles sneak in somewhere? lol, go delete them first.
    - Seriously, CMake, wth.

These step **should** be simplified in the future.