### PR TITLE
Add 64bit lib linkage

### DIFF
--- a/src/servers/Server_Lobby/CMakeLists.txt
+++ b/src/servers/Server_Lobby/CMakeLists.txt
@@ -61,8 +61,16 @@ include_directories(${Boost_INCLUDE_DIR})
 link_directories(${BOOST_LIBRARYDIR})
 link_directories(${SERVER_COMMON_DIR})
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/sapphire/datReader)
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL)
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  # 32 bit link
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL/x86)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib/x86)
+else()
+  # 64 bit link
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL/x64)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib/x64)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY  "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/")
 

--- a/src/servers/Server_REST/CMakeLists.txt
+++ b/src/servers/Server_REST/CMakeLists.txt
@@ -61,8 +61,16 @@ include_directories(${Boost_INCLUDE_DIR})
 link_directories(${BOOST_LIBRARYDIR})
 link_directories(${SERVER_COMMON_DIR})
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/sapphire/datReader)
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL)
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  # 32 bit link
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL/x86)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib/x86)
+else()
+# 64 bit link
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL/x64)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib/x64)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY  "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/")
 add_executable(server_rest ${SERVER_PUBLIC_INCLUDE_FILES} ${SERVER_SOURCE_FILES})

--- a/src/servers/Server_Zone/CMakeLists.txt
+++ b/src/servers/Server_Zone/CMakeLists.txt
@@ -76,8 +76,16 @@ include_directories(${Boost_INCLUDE_DIR})
 link_directories(${BOOST_LIBRARYDIR})
 link_directories(${SERVER_COMMON_DIR})
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/sapphire/datReader)
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL)
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  # 32 bit link
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL/x86)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib/x86)
+else()
+  # 64 bit link
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/MySQL/x64)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/external/zlib/x64)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY  "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/")
 


### PR DESCRIPTION
This was done to reflect this PR: https://github.com/SapphireMordred/SapphireLibs/pull/6

## Notes
After this PR, you'll only need to:
- Compile Boost with 64 bit
- Replace zlib and mysql dynamic library in ```bin``` directory with 64bit version.
[Already compiled for the test purpose.](https://github.com/SapphireMordred/Sapphire/files/1239213/lib.zip)





..to build for 64 bit.
