### PR TITLE
Fix action interrupt crash; Escaping character names; Adjustments to HP formula

### DIFF
--- a/src/servers/Server_REST/PlayerMinimal.cpp
+++ b/src/servers/Server_REST/PlayerMinimal.cpp
@@ -247,7 +247,7 @@ namespace Core {
          " UPDATE_DATE ) "
          " VALUES (100, 100, " + std::to_string( m_iD ) + ", " + std::to_string( m_contentId ) + ", " +
          " UNHEX('" + std::string( Util::binaryToHexString( (uint8_t*)customize, size ) ) + "'), " +
-         "'" + std::string( m_name ) + "', " + std::to_string( m_voice ) + ", 1, 1, " +
+         "'" + g_database.escapeString( std::string( m_name ) ) + "', " + std::to_string( m_voice ) + ", 1, 1, " +
          std::to_string( startZone ) + ", " + std::to_string( x ) + ", " +
          std::to_string( y ) + ", " + std::to_string( z ) + ", " + std::to_string( o ) + ", " +
          std::to_string( m_accountId ) + ", UNHEX('" + std::string( Util::binaryToHexString( (uint8_t*)equipModel, 40 ) ) + "'), 1, NOW());" );

--- a/src/servers/Server_REST/SapphireAPI.cpp
+++ b/src/servers/Server_REST/SapphireAPI.cpp
@@ -235,7 +235,7 @@ std::vector<Core::PlayerMinimal> Core::Network::SapphireAPI::getCharList( uint32
 
 bool Core::Network::SapphireAPI::checkNameTaken( std::string name )
 {
-   std::string query = "SELECT * FROM charabase WHERE Name = '" + name + "';";
+   std::string query = "SELECT * FROM charabase WHERE Name = '" + g_database.escapeString( name ) + "';";
 
    auto pQR = g_database.query( query );
 

--- a/src/servers/Server_Zone/Actor/CalcBattle.cpp
+++ b/src/servers/Server_Zone/Actor/CalcBattle.cpp
@@ -53,8 +53,8 @@ uint32_t CalcBattle::calculateMaxHp( PlayerPtr pPlayer )
    auto classInfoIt = g_exdData.m_classJobInfoMap.find( pPlayer->getClass() );
    auto paramGrowthInfoIt = g_exdData.m_paramGrowthInfoMap.find( pPlayer->getLevel() );
 
-   if (classInfoIt == g_exdData.m_classJobInfoMap.end() ||
-      paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end())
+   if ( classInfoIt == g_exdData.m_classJobInfoMap.end() ||
+      paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end() )
       return 0;
 
    uint8_t level = pPlayer->getLevel();
@@ -87,8 +87,8 @@ uint32_t CalcBattle::calculateMaxMp( PlayerPtr pPlayer )
    auto classInfoIt = g_exdData.m_classJobInfoMap.find( pPlayer->getClass() );
    auto paramGrowthInfoIt = g_exdData.m_paramGrowthInfoMap.find( pPlayer->getLevel() );
 
-   if (classInfoIt == g_exdData.m_classJobInfoMap.end() ||
-      paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end())
+   if ( classInfoIt == g_exdData.m_classJobInfoMap.end() ||
+      paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end() )
       return 0;
 
    float baseStat = calculateBaseStat( pPlayer );

--- a/src/servers/Server_Zone/Actor/CalcBattle.cpp
+++ b/src/servers/Server_Zone/Actor/CalcBattle.cpp
@@ -20,7 +20,7 @@ extern Core::Data::ExdData g_exdData;
    TODO:
 
    Base HP val modifier. I can only find values for levels 50~70.
-   Attack power (and healing power). Need more researchg on this.
+   Attack power (and healing power). Needs more research on this.
    Damage outgoing calculations. This includes auto-attacks, etc.
 
 */
@@ -34,9 +34,9 @@ uint32_t CalcBattle::calculateBaseStat( PlayerPtr pPlayer )
    uint8_t level = pPlayer->getLevel();
 
    if (level < 51)
-      base = static_cast<uint32_t>( 0.053f * ( level * level ) + (1.022f * level) - 0.907f + 20 );
+      base = 0.053f * ( level * level ) + ( 1.022f * level ) - 0.907f + 20;
    else
-      base = static_cast<uint32_t>( 1.627f * level + 120.773f );
+      base = 1.627f * level + 120.773f;
 
    return base;
 }
@@ -46,26 +46,35 @@ uint32_t CalcBattle::calculateBaseStat( PlayerPtr pPlayer )
 
 uint32_t CalcBattle::calculateMaxHp( PlayerPtr pPlayer )
 {
-   // TODO: Replace ApproxBaseHP with something that can get us a BaseHP reliably.
+   // TODO: Replace ApproxBaseHP with something that can get us an accurate BaseHP.
    // Is there any way to pull BaseHP without having to manually use a pet for every level, and using the values from a table?
-
+   // More info here: https://docs.google.com/spreadsheets/d/1de06KGT0cNRUvyiXNmjNgcNvzBCCQku7jte5QxEQRbs/edit?usp=sharing
+   
    auto classInfoIt = g_exdData.m_classJobInfoMap.find( pPlayer->getClass() );
    auto paramGrowthInfoIt = g_exdData.m_paramGrowthInfoMap.find( pPlayer->getLevel() );
 
+   if (classInfoIt == g_exdData.m_classJobInfoMap.end() ||
+      paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end())
+      return 0;
+
+   uint8_t level = pPlayer->getLevel();
+
    float baseStat = calculateBaseStat( pPlayer );
-   uint16_t vit = pPlayer->getStats().vit;
-   uint16_t hp_mod = paramGrowthInfoIt->second.hp_mod;
+   uint16_t vitStat = pPlayer->getStats().vit;
+   uint16_t hpMod = paramGrowthInfoIt->second.hp_mod;
    uint16_t jobModHp = classInfoIt->second.mod_hp;
-   uint16_t approxBaseHp = 0; // Read above
+   float approxBaseHp = 0.0f; // Read above
 
    // These values are not precise.
-   if ( pPlayer->getLevel() > 50 )
-      approxBaseHp = 0.1452f * paramGrowthInfoIt->second.mp_const + 1356.6f;
+
+   if ( level >= 60 )
+      approxBaseHp = 2600 + ( level - 60 ) * 100;
+   else if ( level >= 50 )
+      approxBaseHp = 1700 + ( ( level - 50 ) * ( 1700 * 1.04325f ) );
    else
-      approxBaseHp = paramGrowthInfoIt->second.mp_const * 0.525f;
+      approxBaseHp = paramGrowthInfoIt->second.mp_const * 0.7596f;
 
-   uint16_t result = floor( jobModHp * ( approxBaseHp / 100.0f ) ) + floor( hp_mod / 100.0f * ( vit - baseStat ) );
-
+   uint16_t result = floor( jobModHp * ( approxBaseHp / 100.0f ) ) + floor( hpMod / 100.0f * ( vitStat - baseStat ) );
 
    return result;
 }
@@ -78,13 +87,17 @@ uint32_t CalcBattle::calculateMaxMp( PlayerPtr pPlayer )
    auto classInfoIt = g_exdData.m_classJobInfoMap.find( pPlayer->getClass() );
    auto paramGrowthInfoIt = g_exdData.m_paramGrowthInfoMap.find( pPlayer->getLevel() );
 
+   if (classInfoIt == g_exdData.m_classJobInfoMap.end() ||
+      paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end())
+      return 0;
+
    float baseStat = calculateBaseStat( pPlayer );
    uint16_t piety = pPlayer->getStats().pie;
-   uint16_t piety_scalar = paramGrowthInfoIt->second.mp_mod;
+   uint16_t pietyScalar = paramGrowthInfoIt->second.mp_mod;
    uint16_t jobModMp = classInfoIt->second.mod_mpcpgp;
    uint16_t baseMp = paramGrowthInfoIt->second.mp_const;
 
-   uint16_t result = floor( floor( piety - baseStat ) * ( piety_scalar / 100 ) + baseMp ) * jobModMp / 100;
+   uint16_t result = floor( floor( piety - baseStat ) * ( pietyScalar / 100 ) + baseMp ) * jobModMp / 100;
 
    return result;
 }
@@ -98,7 +111,6 @@ uint32_t CalcBattle::calculateHealValue( PlayerPtr pPlayer, uint32_t potency )
    if ( classInfoIt == g_exdData.m_classJobInfoMap.end() ||
       paramGrowthInfoIt == g_exdData.m_paramGrowthInfoMap.end())
       return 0;
-
 
    auto jobModVal = classInfoIt->second;
 

--- a/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
@@ -108,7 +108,8 @@ void Core::Network::GameConnection::actionHandler( const Packets::GamePacket& in
         }
         case 0x69: // Cancel cast
         {
-           pPlayer->getCurrentAction()->setInterrupted();
+           if( pPlayer->checkAction() )
+               pPlayer->getCurrentAction()->setInterrupted();
            break;
         }
         case 0x133: // Update howtos seen


### PR DESCRIPTION
Zone server would crash upon receiving an action interrupt if there was no active action.
This was made apparent by another issue (#68) in which the server received the action to cancel a cast, but no current action was instanced, which resulted in a crash.

Escaping character names on SQL queries so you can use single quotes in the character name field.

Further adjustments to the HP formula were made.