### PR TITLE
Add Boost_COMPILER flag to CMakeSettings for VS

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,7 +7,13 @@
       "configurationType": "Debug",
       "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "-m -v:minimal"
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc140"
+        }
+      ]
     },
     {
       "name": "x86-Release",
@@ -15,7 +21,13 @@
       "configurationType": "Release",
       "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "-m -v:minimal"
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc140"
+        }
+      ]
     },
     {
       "name": "x64-Debug",
@@ -23,7 +35,13 @@
       "configurationType": "Debug",
       "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "-m -v:minimal"
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc140"
+        }
+      ]
     },
     {
       "name": "x64-Release",
@@ -31,7 +49,13 @@
       "configurationType": "Release",
       "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "-m -v:minimal"
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc140"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
VS2017.3 is shipped with CMake 3.8, which can't find a boost library properly. :<