### PR TITLE
Definition for ActionModel and ActionAspect; Handling removing status from HUD (partial);

### DIFF
--- a/src/servers/Server_Common/Common.h
+++ b/src/servers/Server_Common/Common.h
@@ -557,21 +557,21 @@ namespace Core {
          Unaspected = 7    // Doesn't imply magical unaspected damage - could be unaspected physical
       };
 
-      enum struct ActionModel : int8_t
+      enum struct ActionType : int8_t
       {
-         Physical = -1,
-         Unknown_0 = 0, // Very likely actions that only deals with status effects and nothing else
-         Unknown_1 = 1, // Related to actions that deal with player movement (knockbacks, gapclosers etc)
-         Unknown_2 = 2, // Possibly attacks that bypass calculation (deal raw damage)
-         Unknown_3 = 3, // Possibly AoEs without marker
-         Unknown_4 = 4,
+         WeaponOverride = -1, // Needs more investigation (takes the damage type of the equipped weapon)?
+         Unknown_0 = 0,
+         Slashing = 1, 
+         Piercing = 2, 
+         Blunt = 3,
+         Unknown_4 = 4, 
          Magical = 5,
-         Unknown_6 = 6, // Possibly breath, eye & song attacks
+         Darkness = 6,
          Unknown_7 = 7,
          LimitBreak = 8,
       };
 
-      enum ActionType : uint8_t
+      enum HandleActionType : uint8_t
       {
          Event,
          Spell,

--- a/src/servers/Server_Common/Common.h
+++ b/src/servers/Server_Common/Common.h
@@ -545,13 +545,37 @@ namespace Core {
          FcTalk = 0x001F,
       };
 
+      enum struct ActionAspect : uint8_t
+      {
+         None = 0,   // Doesn't imply unaspected
+         Fire = 1,
+         Ice = 2,
+         Wind = 3,
+         Stone = 4,
+         Lightning = 5,
+         Water = 6,
+         Unaspected = 7    // Doesn't imply magical unaspected damage - could be unaspected physical
+      };
+
+      enum struct ActionModel : int8_t
+      {
+         Physical = -1,
+         Unknown_0 = 0, // Very likely actions that only deals with status effects and nothing else
+         Unknown_1 = 1, // Related to actions that deal with player movement (knockbacks, gapclosers etc)
+         Unknown_2 = 2, // Possibly attacks that bypass calculation (deal raw damage)
+         Unknown_3 = 3, // Possibly AoEs without marker
+         Unknown_4 = 4,
+         Magical = 5,
+         Unknown_6 = 6, // Possibly breath, eye & song attacks
+         Unknown_7 = 7,
+         LimitBreak = 8,
+      };
+
       enum ActionType : uint8_t
       {
-
          Event,
          Spell,
          Teleport
-
       };
 
       enum HandleSkillType : uint8_t

--- a/src/servers/Server_Common/Exd/ExdData.cpp
+++ b/src/servers/Server_Common/Exd/ExdData.cpp
@@ -324,28 +324,33 @@ bool Core::Data::ExdData::loadActionInfo()
          continue;
       }
 
-      std::string name = getField< std::string >( fields, 0 );
-      uint8_t category = getField< uint8_t >( fields, 3 );
+      std::string name = getField< std::string >( fields, 0 );    // 0
+      uint8_t category = getField< uint8_t >( fields, 3 );        // 3
 
-      int8_t class_job = getField< int8_t >( fields, 10 );//9
-      uint8_t unlock_level = getField< uint8_t >( fields, 11 );//10
-      int8_t range = getField< int8_t >( fields, 13 );//11
-      bool can_target_self = getField< bool >( fields, 14 );//12
-      bool can_target_party = getField< bool>( fields, 15 );//13
-      bool can_target_friendly = getField< bool >( fields, 16 );//14
-      bool can_target_enemy = getField< bool >( fields, 17 );//15
+      int8_t class_job = getField< int8_t >( fields, 10 );        // 10
+      uint8_t unlock_level = getField< uint8_t >( fields, 11 );   // 11
+      int8_t range = getField< int8_t >( fields, 13 );            // 13
+      bool can_target_self = getField< bool >( fields, 14 );      // 14
+      bool can_target_party = getField< bool>( fields, 15 );      // 15
+      bool can_target_friendly = getField< bool >( fields, 16 );  // 16
+      bool can_target_enemy = getField< bool >( fields, 17 );     // 17
 
-      bool is_aoe = getField< bool >( fields, 20 );//18
+      bool is_aoe = getField< bool >( fields, 20 );               // 20
+      // Column 23: Seems to be related to raising skills (Raise, Resurrection, Reanimate)
+      bool can_target_ko = getField< bool >( fields, 24 );        // 24
 
-      bool can_target_ko = getField< bool >( fields, 24 );//22
+      uint8_t aoe_type = getField< uint8_t >( fields, 26 );       // 26
+      uint8_t radius = getField< uint8_t >( fields, 27 );         // 27
 
-      uint8_t aoe_type = getField< uint8_t >( fields, 26 );//24
-      uint8_t radius = getField< uint8_t >( fields, 27 );//25
+      uint8_t points_type = getField< uint8_t >( fields, 30 );    // 30
+      uint16_t points_cost = getField< uint16_t >( fields, 31 );  // 31
 
-      uint8_t points_type = getField< uint8_t >( fields, 30 );//28
-      uint16_t points_cost = getField< uint16_t >( fields, 31 );//29
+      uint32_t instantval = getField< bool >( fields, 35 );       // 35
+      uint16_t cast_time = getField< uint16_t >(fields, 36);      // 36
+      uint16_t recast_time = getField< uint16_t >(fields, 37);    // 37
 
-      uint32_t instantval = getField< bool >( fields, 35 );
+      uint16_t type = getField< uint16_t >(fields, 39);           // 39: Action type
+      uint16_t aspect = getField< uint16_t >(fields, 40);         // 40: Action aspect
 
       uint8_t typeshift = 0x6;
       uint8_t mask = 1 << typeshift;
@@ -353,8 +358,7 @@ bool Core::Data::ExdData::loadActionInfo()
       bool final = ( instantval & mask ) == mask;
       bool is_instant = final;
 
-      uint16_t cast_time = getField< uint16_t >( fields, 36 );
-      uint16_t recast_time = getField< uint16_t >( fields, 37 );
+      
 
       info.id = id;
       info.name = name;

--- a/src/servers/Server_Common/Exd/ExdData.cpp
+++ b/src/servers/Server_Common/Exd/ExdData.cpp
@@ -346,11 +346,11 @@ bool Core::Data::ExdData::loadActionInfo()
       uint16_t points_cost = getField< uint16_t >( fields, 31 );  // 31
 
       uint32_t instantval = getField< bool >( fields, 35 );       // 35
-      uint16_t cast_time = getField< uint16_t >(fields, 36);      // 36
-      uint16_t recast_time = getField< uint16_t >(fields, 37);    // 37
+      uint16_t cast_time = getField< uint16_t >( fields, 36 );    // 36
+      uint16_t recast_time = getField< uint16_t >( fields, 37 );  // 37
 
-      uint16_t type = getField< uint16_t >(fields, 39);           // 39: Action type
-      uint16_t aspect = getField< uint16_t >(fields, 40);         // 40: Action aspect
+      int8_t model = getField< int8_t >( fields, 39 );            // 39: Action model
+      uint8_t aspect = getField< uint8_t >( fields, 40 );          // 40: Action aspect
 
       uint8_t typeshift = 0x6;
       uint8_t mask = 1 << typeshift;
@@ -385,6 +385,9 @@ bool Core::Data::ExdData::loadActionInfo()
       info.is_instant = is_instant;
       info.cast_time = cast_time * 100;
       info.recast_time = recast_time * 100;
+
+      info.model = model;
+      info.aspect = aspect;
 
       m_actionInfoMap[id] = info;
 

--- a/src/servers/Server_Common/Exd/ExdData.h
+++ b/src/servers/Server_Common/Exd/ExdData.h
@@ -222,30 +222,33 @@ namespace Core {
       struct ActionInfo
       {
          uint32_t id;
-         std::string name; //0
-         uint16_t category;//3
+         std::string name;          // 0
+         uint16_t category;         // 3
 
-         int8_t class_job;//9
-         uint8_t unlock_level;//10
-         int8_t range;//11
-         bool can_target_self;//12
-         bool can_target_party;//13
-         bool can_target_friendly;//14
-         bool can_target_enemy;//15
+         int8_t class_job;          // 10
+         uint8_t unlock_level;      // 11
+         int8_t range;              // 13
+         bool can_target_self;      // 14
+         bool can_target_party;     // 15
+         bool can_target_friendly;  // 16
+         bool can_target_enemy;     // 17
 
-         bool is_aoe;//18
+         bool is_aoe;               // 20
 
-         bool can_target_ko;//22
+         bool can_target_ko;        // 24
 
-         uint8_t aoe_type;//24
-         uint8_t radius;//25
+         uint8_t aoe_type;          // 26
+         uint8_t radius;            // 27
 
-         uint8_t points_type;//28
-         uint16_t points_cost;//29
+         uint8_t points_type;       // 30
+         uint16_t points_cost;      // 31
 
-         bool is_instant;//33
-         uint32_t cast_time;//34
-         uint32_t recast_time;//35
+         bool is_instant;           // 35
+         uint32_t cast_time;        // 36
+         uint32_t recast_time;      // 37
+
+         uint8_t type;              // 39
+         uint8_t aspect;            // 40
       };
 
       struct EventItemInfo

--- a/src/servers/Server_Common/Exd/ExdData.h
+++ b/src/servers/Server_Common/Exd/ExdData.h
@@ -247,7 +247,7 @@ namespace Core {
          uint32_t cast_time;        // 36
          uint32_t recast_time;      // 37
 
-         uint8_t type;              // 39
+         int8_t model;              // 39
          uint8_t aspect;            // 40
       };
 

--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -299,7 +299,7 @@ struct effectEntry
    uint8_t unknown_2;
    uint8_t unknown_3;
    int8_t bonusPercent;
-   int16_t param1;
+   int16_t dmgValue;
    uint8_t unknown_5;
    uint8_t unknown_6;
 };

--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -299,7 +299,7 @@ struct effectEntry
    uint8_t unknown_2;
    uint8_t unknown_3;
    int8_t bonusPercent;
-   int16_t dmgValue;
+   int16_t param1;
    uint8_t unknown_5;
    uint8_t unknown_6;
 };

--- a/src/servers/Server_Zone/Action/Action.cpp
+++ b/src/servers/Server_Zone/Action/Action.cpp
@@ -17,9 +17,9 @@ uint32_t Core::Action::Action::getId() const
    return m_id;
 }
 
-Core::Common::ActionType Core::Action::Action::getActionType() const
+Core::Common::HandleActionType Core::Action::Action::getHandleActionType() const
 {
-   return m_actionType;
+   return m_handleActionType;
 }
 
 Core::Entity::ActorPtr Core::Action::Action::getTargetActor() const

--- a/src/servers/Server_Zone/Action/Action.h
+++ b/src/servers/Server_Zone/Action/Action.h
@@ -6,6 +6,32 @@
 
 namespace Core { namespace Action {
 
+   enum struct ActionAspect : uint32_t
+   {
+      None       = 0,   // Doesn't imply unaspected
+      Fire       = 1,
+      Ice        = 2,
+      Wind       = 3,
+      Stone      = 4,
+      Lightning  = 5,
+      Water      = 6,
+      Unaspected = 7    // Doesn't imply magical unaspected damage - could be unaspected physical
+   };
+
+   enum struct ActionType : int16_t
+   {
+      Physical   = -1,
+      Unknown_0  = 0, // Very likely actions that only deals with status effects and nothing else
+      Unknown_1  = 1, // Related to actions that deal with player movement (knockbacks, gapclosers etc)
+      Unknown_2  = 2, // Possibly attacks that bypass calculation (deal raw damage)
+      Unknown_3  = 3, // Possibly AoEs without marker
+      Unknown_4  = 4,
+      Magical    = 5,
+      Unknown_6  = 6, // Possibly breath, eye & song attacks
+      Unknown_7  = 7,
+      LimitBreak = 8,
+   };
+
    class Action 
    {
 

--- a/src/servers/Server_Zone/Action/Action.h
+++ b/src/servers/Server_Zone/Action/Action.h
@@ -6,32 +6,6 @@
 
 namespace Core { namespace Action {
 
-   enum struct ActionAspect : uint32_t
-   {
-      None       = 0,   // Doesn't imply unaspected
-      Fire       = 1,
-      Ice        = 2,
-      Wind       = 3,
-      Stone      = 4,
-      Lightning  = 5,
-      Water      = 6,
-      Unaspected = 7    // Doesn't imply magical unaspected damage - could be unaspected physical
-   };
-
-   enum struct ActionType : int16_t
-   {
-      Physical   = -1,
-      Unknown_0  = 0, // Very likely actions that only deals with status effects and nothing else
-      Unknown_1  = 1, // Related to actions that deal with player movement (knockbacks, gapclosers etc)
-      Unknown_2  = 2, // Possibly attacks that bypass calculation (deal raw damage)
-      Unknown_3  = 3, // Possibly AoEs without marker
-      Unknown_4  = 4,
-      Magical    = 5,
-      Unknown_6  = 6, // Possibly breath, eye & song attacks
-      Unknown_7  = 7,
-      LimitBreak = 8,
-   };
-
    class Action 
    {
 

--- a/src/servers/Server_Zone/Action/Action.h
+++ b/src/servers/Server_Zone/Action/Action.h
@@ -15,7 +15,7 @@ namespace Core { namespace Action {
 
       uint32_t getId() const;
 
-      Common::ActionType getActionType() const;
+      Common::HandleActionType getHandleActionType() const;
 
       Entity::ActorPtr getTargetActor() const;
 
@@ -42,7 +42,7 @@ namespace Core { namespace Action {
 
    protected:
       uint32_t	m_id;
-      Common::ActionType m_actionType;
+      Common::HandleActionType m_handleActionType;
 
       uint64_t	m_startTime;
       uint32_t	m_castTime;

--- a/src/servers/Server_Zone/Action/ActionCast.cpp
+++ b/src/servers/Server_Zone/Action/ActionCast.cpp
@@ -22,14 +22,14 @@ extern Core::Scripting::ScriptManager g_scriptMgr;
 
 Core::Action::ActionCast::ActionCast()
 {
-   m_actionType = Common::ActionType::Event;
+   m_handleActionType = Common::HandleActionType::Event;
 }
 
 Core::Action::ActionCast::ActionCast( Entity::ActorPtr pActor, Entity::ActorPtr pTarget, uint32_t actionId )
 {
    m_startTime = 0;
    m_id = actionId;
-   m_actionType = ActionType::Spell;
+   m_handleActionType = HandleActionType::Spell;
    m_castTime = g_exdData.m_actionInfoMap[actionId].cast_time; // TODO: Add security checks.
    m_pSource = pActor;
    m_pTarget = pTarget;

--- a/src/servers/Server_Zone/Action/ActionTeleport.cpp
+++ b/src/servers/Server_Zone/Action/ActionTeleport.cpp
@@ -18,14 +18,14 @@ extern Core::Logger g_log;
 
 Core::Action::ActionTeleport::ActionTeleport()
 {
-   m_actionType = Common::ActionType::Event;
+   m_handleActionType = Common::HandleActionType::Event;
 }
 
 Core::Action::ActionTeleport::ActionTeleport( Entity::ActorPtr pActor, uint16_t targetZone, uint16_t cost )
 {
    m_startTime = 0;
    m_id = 5;
-   m_actionType = ActionType::Teleport;
+   m_handleActionType = HandleActionType::Teleport;
    m_castTime = g_exdData.m_actionInfoMap[5].cast_time; // TODO: Add security checks.
    m_pSource = pActor;
    m_bInterrupt = false;

--- a/src/servers/Server_Zone/Action/EventAction.cpp
+++ b/src/servers/Server_Zone/Action/EventAction.cpp
@@ -18,14 +18,14 @@ using namespace Core::Network::Packets::Server;
 
 Core::Action::EventAction::EventAction()
 {
-   m_actionType = Common::ActionType::Event;
+   m_handleActionType = Common::HandleActionType::Event;
 }
 
 Core::Action::EventAction::EventAction( Entity::ActorPtr pActor, uint32_t eventId, uint16_t action,
                                         ActionCallback finishRef, ActionCallback interruptRef, uint64_t additional )
 {
    m_additional = additional;
-   m_actionType = ActionType::Event;
+   m_handleActionType = HandleActionType::Event;
    m_eventId = eventId;
    m_id = action;
    m_castTime = g_exdData.m_EventActionInfoMap[action].castTime; // TODO: Add security checks.

--- a/src/servers/Server_Zone/Action/EventItemAction.cpp
+++ b/src/servers/Server_Zone/Action/EventItemAction.cpp
@@ -19,14 +19,14 @@ using namespace Core::Network::Packets::Server;
 
 Core::Action::EventItemAction::EventItemAction()
 {
-   m_actionType = Common::ActionType::Event;
+   m_handleActionType = Common::HandleActionType::Event;
 }
 
 Core::Action::EventItemAction::EventItemAction( Entity::ActorPtr pActor, uint32_t eventId, uint32_t action,
                                                 ActionCallback finishRef, ActionCallback interruptRef, uint64_t additional )
 {
    m_additional = additional;
-   m_actionType = ActionType::Event;
+   m_handleActionType = HandleActionType::Event;
    m_eventId = eventId;
    m_id = action;
    // TODO: read the cast time from the action itself

--- a/src/servers/Server_Zone/Actor/Actor.cpp
+++ b/src/servers/Server_Zone/Actor/Actor.cpp
@@ -645,3 +645,8 @@ void Core::Entity::Actor::addStatusEffectByIdIfNotExist( int32_t id, int32_t dur
    }
 }
 
+/*! \param Status that should be removed, based on its ID. */
+void Core::Entity::Actor::removeSingleStatusEffectFromId( int32_t id )
+{
+   m_pStatusEffectContainer->removeSingleStatusEffectFromId( id );
+}

--- a/src/servers/Server_Zone/Actor/Actor.h
+++ b/src/servers/Server_Zone/Actor/Actor.h
@@ -298,6 +298,9 @@ public:
    // add a status effect by id if it doesn't exist
    void addStatusEffectByIdIfNotExist( int32_t id, int32_t duration, uint16_t param = 0 );
 
+   // remove a status effect by id
+   void removeSingleStatusEffectFromId( int32_t id );
+
    // TODO: Why did i even declare them publicly here?!
    std::set< ActorPtr >            m_inRangeActors;
    std::set< PlayerPtr >           m_inRangePlayers;

--- a/src/servers/Server_Zone/Actor/Player.cpp
+++ b/src/servers/Server_Zone/Actor/Player.cpp
@@ -1460,9 +1460,9 @@ void Core::Entity::Player::autoAttack( ActorPtr pTarget )
    uint32_t damage = mainWeap->getAutoAttackDmg();
    uint32_t variation = 0 + rand() % 3;
 
-   if (getClass() == JOB_MACHINIST ||
+   if ( getClass() == JOB_MACHINIST ||
       getClass() == JOB_BARD ||
-      getClass() == CLASS_ARCHER)
+      getClass() == CLASS_ARCHER )
    {
       GamePacketNew< FFXIVIpcEffect, ServerZoneIpcType > effectPacket(getId());
       effectPacket.data().targetId = pTarget->getId();

--- a/src/servers/Server_Zone/Actor/Player.h
+++ b/src/servers/Server_Zone/Actor/Player.h
@@ -207,7 +207,7 @@ public:
    /*! equip a weapon, possibly forcing a job change */
    void equipWeapon( ItemPtr pItem );
    /*! get a const pointer to the inventory object */
-   InventoryPtr getInvetory() const;
+   InventoryPtr getInventory() const;
    /*! get the current main hand model */
    uint64_t getModelMainWeapon() const;
    /*! get the current off hand model */

--- a/src/servers/Server_Zone/Actor/PlayerInventory.cpp
+++ b/src/servers/Server_Zone/Actor/PlayerInventory.cpp
@@ -16,7 +16,7 @@ using namespace Core::Common;
 using namespace Core::Network::Packets;
 using namespace Core::Network::Packets::Server;
 
-Core::InventoryPtr Core::Entity::Player::getInvetory() const
+Core::InventoryPtr Core::Entity::Player::getInventory() const
 {
    return m_pInventory;
 }

--- a/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
@@ -106,6 +106,12 @@ void Core::Network::GameConnection::actionHandler( const Packets::GamePacket& in
             pPlayer->changeTarget( targetId );
             break;
         }
+        case 0x68: // Remove status (clicking it off)
+        {
+           // todo: check if status can be removed by client from exd
+           pPlayer->removeSingleStatusEffectFromId( param1 );
+           break;
+        }
         case 0x69: // Cancel cast
         {
            if( pPlayer->checkAction() )

--- a/src/servers/Server_Zone/Network/Handlers/InventoryHandler.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/InventoryHandler.cpp
@@ -63,19 +63,19 @@ void Core::Network::GameConnection::inventoryModifyHandler( const Packets::GameP
 
         case 0x07: // discard item action
         {
-            pPlayer->getInvetory()->discardItem( fromContainer, fromSlot );
+            pPlayer->getInventory()->discardItem( fromContainer, fromSlot );
         }
             break;
 
         case 0x08: // move item action
         {
-            pPlayer->getInvetory()->moveItem( fromContainer, fromSlot, toContainer, toSlot );
+            pPlayer->getInventory()->moveItem( fromContainer, fromSlot, toContainer, toSlot );
         }
             break;
 
         case 0x09: // swap item action
         {
-            pPlayer->getInvetory()->swapItem( fromContainer, fromSlot, toContainer, toSlot );
+            pPlayer->getInventory()->swapItem( fromContainer, fromSlot, toContainer, toSlot );
         }
             break;
 

--- a/src/servers/Server_Zone/Network/PacketWrappers/PlayerSpawnPacket.h
+++ b/src/servers/Server_Zone/Network/PacketWrappers/PlayerSpawnPacket.h
@@ -47,7 +47,7 @@ namespace Server {
          //m_data.tPMax = 3000;
          m_data.level = pPlayer->getLevel();
          memcpy( m_data.look, pPlayer->getLookArray(), 26 );
-         auto item = pPlayer->getInvetory()->getItemAt( Inventory::GearSet0, 0 );
+         auto item = pPlayer->getInventory()->getItemAt( Inventory::GearSet0, Inventory::EquipSlot::MainHand );
          if( item )
             m_data.mainWeaponModel = item->getModelId1();
          m_data.secWeaponModel = pPlayer->getModelSubWeapon();

--- a/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.cpp
+++ b/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.cpp
@@ -76,6 +76,18 @@ void Core::StatusEffect::StatusEffectContainer::addStatusEffect( StatusEffectPtr
 
 }
 
+void Core::StatusEffect::StatusEffectContainer::removeSingleStatusEffectFromId( uint32_t id )
+{
+   for (auto effectIt : m_effectMap)
+   {
+      if (effectIt.second->getId() == id)
+      {
+         removeStatusEffect( effectIt.first );
+         break;
+      }
+   }
+}
+
 void Core::StatusEffect::StatusEffectContainer::removeStatusEffect( uint8_t effectSlotId )
 {
    auto pEffectIt = m_effectMap.find( effectSlotId );

--- a/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.h
+++ b/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.h
@@ -21,6 +21,7 @@ public:
 
    void addStatusEffect( StatusEffectPtr pEffect );
    void removeStatusEffect( uint8_t effectSlotId );
+   void removeSingleStatusEffectFromId( uint32_t id );
    void update();
 
    bool hasStatusEffect( uint32_t id );


### PR DESCRIPTION
Not much.
Definitions for presumably data for an action aspect, as well as an action's model. Open to ideas for better naming - was initially ActionType but that was already taken.

Handling removing status off from the HUD (aka "clicking" it off from the status bar) - this is defined as partial due to not handling which status effects are allowed to be removed (one could send in a packet that removes a poison status disguised for example).
Likely a boolean on one of the columns in the game's data.
There's also something weird going on between zoning. Seeing how our current status zoning implementation doesn't match retail (ie. doesn't stay between zones), leaving it at that.