### PR TITLE
Add chat restricted packet def

### DIFF
--- a/src/servers/Server_Common/Network/PacketDef/Ipcs.h
+++ b/src/servers/Server_Common/Network/PacketDef/Ipcs.h
@@ -47,7 +47,7 @@ namespace Packets {
       Ping                       = 0x0065, // updated for sb
       Init                       = 0x0066, // updated for sb
       Chat                       = 0x0067, // updated for sb
-
+      ChatBanned                 = 0x006B,
       Logout                     = 0x0077, // updated for sb
       CFNotify                   = 0x0078,
       CFMemberStatus             = 0x0079,

--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -48,6 +48,12 @@ struct FFXIVIpcChat : FFXIVIpcBasePacket<Chat>
    char msg[1012];
 };
 
+struct FFXIVIpcChatBanned : FFXIVIpcBasePacket<ChatBanned>
+{
+   uint8_t padding[4]; // I was not sure reinterpreting ZST is valid behavior in C++.
+                     // client doesn't care about the data (zero sized) for this opcode anyway.
+};
+
 /**
 * Structural representation of the packet sent by the server
 * carrying chat messages
@@ -1216,7 +1222,7 @@ struct FFXIVIpcCFNotify : FFXIVIpcBasePacket<CFNotify>
     uint32_t param1; // usually classJobId
     uint32_t param2; // usually flag
     uint32_t param3; // usually languages, sometimes join in progress timestamp
-    
+
     uint16_t param4; // usually roulette id
     uint16_t contents[5];
 };


### PR DESCRIPTION
RVA of opcode 0x6B is located at 0xB432E0 (4.06, post hotfix)

Note: This is zero sized. Client won't even pass a data pointer to the handler.

## Example
![2017-09-10 3](https://user-images.githubusercontent.com/1381835/30246298-f6b326ac-9630-11e7-8d6d-fef82e37a328.png)
