### PR TITLE
Status effect source reference; ActionCast battle log work; Cleaning compiler warnings up a bit;

### DIFF
--- a/scripts/chai/skill/cnj/skillDef_121.chai
+++ b/scripts/chai/skill/cnj/skillDef_121.chai
@@ -11,7 +11,7 @@ class skillDef_121Def
     def onFinish( player, target )
     {
     	player.handleScriptSkill( STD_DAMAGE, 121, 50, 0, target );
-        target.addStatusEffectByIdIfNotExist(143, 20000, 0);
+        target.addStatusEffectByIdIfNotExist(143, 20000, player, 0);
     }
 
 };

--- a/scripts/chai/skill/cnj/skillDef_125.chai
+++ b/scripts/chai/skill/cnj/skillDef_125.chai
@@ -10,7 +10,7 @@ class skillDef_125Def
 
     def onFinish( player, target )
     {
-        target.addStatusEffectByIdIfNotExist( 148, 60000, 0 );
+        target.addStatusEffectByIdIfNotExist( 148, 60000, player, 0 );
     }
 
 };

--- a/scripts/chai/skill/cnj/skillDef_128.chai
+++ b/scripts/chai/skill/cnj/skillDef_128.chai
@@ -10,7 +10,7 @@ class skillDef_128Def
 
     def onFinish( player, target )
     {
-        target.addStatusEffectByIdIfNotExist(3, 30000, 0);
+        target.addStatusEffectByIdIfNotExist( 3, 30000, player, 0 );
     }
 
 };

--- a/scripts/chai/skill/cnj/skillDef_132.chai
+++ b/scripts/chai/skill/cnj/skillDef_132.chai
@@ -11,7 +11,7 @@ class skillDef_132Def
     def onFinish( player, target )
     {
     	player.handleScriptSkill( STD_DAMAGE, 132, 50, 0, target );
-        target.addStatusEffectByIdIfNotExist( 143, 20000, 0 );
+        target.addStatusEffectByIdIfNotExist( 143, 20000, player, 0 );
     }
 
 };

--- a/scripts/chai/skill/skillDef_3.chai
+++ b/scripts/chai/skill/skillDef_3.chai
@@ -10,7 +10,7 @@ class skillDef_3Def
 
     def onFinish( player, target )
     {
-        player.addStatusEffectById(50, 20000, 30);
+        player.addStatusEffectById(50, 20000, player, 30);
     }
 
 };

--- a/src/servers/Server_Common/Common.h
+++ b/src/servers/Server_Common/Common.h
@@ -743,7 +743,7 @@ namespace Core {
 
          Flee = 0x1B,
 
-         Unk3 = 0x20,
+         Unk3 = 0x20,                  // Animation related?
 
          CombatIndicationShow = 0x22,
 
@@ -769,7 +769,7 @@ namespace Core {
          ItemRepairMsg = 0x5C,
 
          LeveStartAnim = 0x66,
-         Unk4 = 0x67,
+         LeveStartError = 0x67,
          PlayerNameGrayout = 0x6A,
 
          ItemObtainMsg = 0x75,
@@ -869,7 +869,7 @@ namespace Core {
 
          AchievementPopup = 0x203,
 
-         Unk7 = 0x205,
+         Unk7 = 0x205,                 // LogMessage?
          AchievementMsg = 0x206,
 
          SetItemLevel = 0x209,

--- a/src/servers/Server_Zone/Action/ActionCast.cpp
+++ b/src/servers/Server_Zone/Action/ActionCast.cpp
@@ -8,6 +8,7 @@
 
 #include "src/servers/Server_Zone/Network/PacketWrappers/ActorControlPacket142.h"
 #include "src/servers/Server_Zone/Network/PacketWrappers/ActorControlPacket143.h"
+#include "src/servers/Server_Zone/Network/PacketWrappers/ActorControlPacket144.h"
 #include "src/servers/Server_Zone/Actor/Player.h"
 #include "src/servers/Server_Zone/Script/ScriptManager.h"
 
@@ -53,10 +54,11 @@ void Core::Action::ActionCast::onStart()
 
    castPacket.data().action_id = m_id;
    castPacket.data().unknown = 1;
-   castPacket.data().cast_time = m_castTime / 1000; // This is used for the cast bar above the target bar of the caster.
+   castPacket.data().unknown_1 = m_id;
+   castPacket.data().cast_time = static_cast< float >( m_castTime / 1000 ); // This is used for the cast bar above the target bar of the caster.
    castPacket.data().target_id = m_pTarget->getId();
 
-   m_pSource->sendToInRangeSet( castPacket, false );
+   m_pSource->sendToInRangeSet( castPacket, true );
    m_pSource->getAsPlayer()->setStateFlag( PlayerStateFlag::Casting );
    m_pSource->getAsPlayer()->sendStateFlags();
 
@@ -73,6 +75,10 @@ void Core::Action::ActionCast::onFinish()
    pPlayer->unsetStateFlag( PlayerStateFlag::Casting );
    pPlayer->sendStateFlags();
 
+   /*auto control = ActorControlPacket143( m_pTarget->getId(), ActorControlType::Unk7,
+                                         0x219, m_id, m_id, m_id, m_id );
+   m_pSource->sendToInRangeSet( control, true );*/
+
    g_scriptMgr.onCastFinish( pPlayer, m_pTarget, m_id );
 }
 
@@ -86,7 +92,7 @@ void Core::Action::ActionCast::onInterrupt()
    m_pSource->getAsPlayer()->sendStateFlags();
 
    auto control = ActorControlPacket142( m_pSource->getId(), ActorControlType::CastInterrupt,
-                                          0x219, 0x04, m_id, 1 );
+                                          0x219, 1, m_id, 1 );
    m_pSource->sendToInRangeSet( control, true );
 
 }

--- a/src/servers/Server_Zone/Actor/Actor.cpp
+++ b/src/servers/Server_Zone/Actor/Actor.cpp
@@ -627,26 +627,26 @@ void Core::Entity::Actor::addStatusEffect( StatusEffect::StatusEffectPtr pEffect
 }
 
 /*! \param StatusEffectPtr to be applied to the actor */
-void Core::Entity::Actor::addStatusEffectById( int32_t id, int32_t duration, uint16_t param )
+void Core::Entity::Actor::addStatusEffectById( uint32_t id, int32_t duration, Entity::Actor& pSource, uint16_t param )
 {
-   StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, shared_from_this(), shared_from_this(), duration, 3000 ) );
+   StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, pSource.shared_from_this(), shared_from_this(), duration, 3000 ) );
    effect->setParam( param );
    addStatusEffect( effect );
 }
 
 /*! \param StatusEffectPtr to be applied to the actor */
-void Core::Entity::Actor::addStatusEffectByIdIfNotExist( int32_t id, int32_t duration, uint16_t param )
+void Core::Entity::Actor::addStatusEffectByIdIfNotExist( uint32_t id, int32_t duration, Entity::Actor& pSource, uint16_t param )
 {
    if( !m_pStatusEffectContainer->hasStatusEffect( id ) )
    {
-      StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, shared_from_this(), shared_from_this(), duration, 3000 ) );
+      StatusEffect::StatusEffectPtr effect( new StatusEffect::StatusEffect( id, pSource.shared_from_this(), shared_from_this(), duration, 3000 ) );
       effect->setParam( param );
       addStatusEffect( effect );
    }
 }
 
 /*! \param Status that should be removed, based on its ID. */
-void Core::Entity::Actor::removeSingleStatusEffectFromId( int32_t id )
+void Core::Entity::Actor::removeSingleStatusEffectFromId( uint32_t id )
 {
    m_pStatusEffectContainer->removeSingleStatusEffectFromId( id );
 }

--- a/src/servers/Server_Zone/Actor/Actor.h
+++ b/src/servers/Server_Zone/Actor/Actor.h
@@ -293,13 +293,13 @@ public:
    void addStatusEffect( StatusEffect::StatusEffectPtr pEffect );
 
    // add a status effect by id
-   void addStatusEffectById( int32_t id, int32_t duration, uint16_t param = 0 );
+   void addStatusEffectById( uint32_t id, int32_t duration, Entity::Actor& pSource, uint16_t param = 0 );
 
    // add a status effect by id if it doesn't exist
-   void addStatusEffectByIdIfNotExist( int32_t id, int32_t duration, uint16_t param = 0 );
+   void addStatusEffectByIdIfNotExist( uint32_t id, int32_t duration, Entity::Actor& pSource, uint16_t param = 0 );
 
    // remove a status effect by id
-   void removeSingleStatusEffectFromId( int32_t id );
+   void removeSingleStatusEffectFromId( uint32_t id );
 
    //get the status effect container
    StatusEffect::StatusEffectContainerPtr getStatusEffectContainer() const;

--- a/src/servers/Server_Zone/Actor/BattleNpc.cpp
+++ b/src/servers/Server_Zone/Actor/BattleNpc.cpp
@@ -425,7 +425,7 @@ void Core::Entity::BattleNpc::onDeath()
          // todo: check for companion
          if( pHateEntry->m_pActor->isPlayer()  ) // && pHateEntry->m_hateAmount >= plsBeHatedThisMuchAtLeast )
          {
-            auto level = pHateEntry->m_pActor->getLevel();
+            uint8_t level = pHateEntry->m_pActor->getLevel();
             auto levelDiff = (int)this->m_level - (int)level;
             auto cappedLevelDiff = Math::Util::clamp( levelDiff, 1, 6 );
 

--- a/src/servers/Server_Zone/Actor/CalcBattle.cpp
+++ b/src/servers/Server_Zone/Actor/CalcBattle.cpp
@@ -29,7 +29,7 @@ extern Core::Data::ExdData g_exdData;
 // 3 Versions. SB and HW are linear, ARR is polynomial.
 // Originally from Player.cpp, calculateStats().
 
-uint32_t CalcBattle::calculateBaseStat( PlayerPtr pPlayer )
+float CalcBattle::calculateBaseStat( PlayerPtr pPlayer )
 {
    float base = 0.0f;
    uint8_t level = pPlayer->getLevel();
@@ -37,7 +37,7 @@ uint32_t CalcBattle::calculateBaseStat( PlayerPtr pPlayer )
    // SB Base Stat Formula  (Aligned)
    if ( level > 60 )
    { 
-      base = ( ( ( level == 61) ? 224 : 220 ) + ( level - 61 ) * 8);
+      base = ( ( ( level == 61 ) ? 224 : 220 ) + ( level - 61 ) * 8);
    }
    // HW Base Stat Formula  (Aligned)
    else if ( level > 50 )
@@ -85,7 +85,7 @@ uint32_t CalcBattle::calculateMaxHp( PlayerPtr pPlayer )
    else
       approxBaseHp = paramGrowthInfoIt->second.mp_const * 0.7596f;
 
-   uint16_t result = floor( jobModHp * ( approxBaseHp / 100.0f ) ) + floor( hpMod / 100.0f * ( vitStat - baseStat ) );
+   uint16_t result = static_cast< uint16_t >( floor( jobModHp * ( approxBaseHp / 100.0f ) ) + floor( hpMod / 100.0f * ( vitStat - baseStat ) ) );
 
    return result;
 }
@@ -108,7 +108,7 @@ uint32_t CalcBattle::calculateMaxMp( PlayerPtr pPlayer )
    uint16_t jobModMp = classInfoIt->second.mod_mpcpgp;
    uint16_t baseMp = paramGrowthInfoIt->second.mp_const;
 
-   uint16_t result = floor( floor( piety - baseStat ) * ( pietyScalar / 100 ) + baseMp ) * jobModMp / 100;
+   uint16_t result = static_cast< uint16_t >( floor( floor( piety - baseStat ) * ( pietyScalar / 100 ) + baseMp ) * jobModMp / 100 );
 
    return result;
 }

--- a/src/servers/Server_Zone/Actor/CalcBattle.h
+++ b/src/servers/Server_Zone/Actor/CalcBattle.h
@@ -12,7 +12,7 @@ namespace Entity {
    {
    public:
 
-      static uint32_t calculateBaseStat( PlayerPtr pPlayer );
+      static float calculateBaseStat( PlayerPtr pPlayer );
       static uint32_t calculateMaxMp( PlayerPtr pPlayer );
       static uint32_t calculateMaxHp( PlayerPtr pPlayer );
       static uint32_t calculateHealValue( PlayerPtr pPlayer, uint32_t potency );

--- a/src/servers/Server_Zone/Actor/Player.cpp
+++ b/src/servers/Server_Zone/Actor/Player.cpp
@@ -218,12 +218,12 @@ void Core::Entity::Player::calculateStats()
    // TODO: put formula somewhere else...
    float base = CalcBattle::calculateBaseStat( getAsPlayer() );
 
-   m_baseStats.str =  base * ( static_cast< float >( classInfo.mod_str ) / 100 ) + tribeInfo.mod_str;
-   m_baseStats.dex =  base * ( static_cast< float >( classInfo.mod_dex ) / 100 ) + tribeInfo.mod_dex;
-   m_baseStats.vit =  base * ( static_cast< float >( classInfo.mod_vit ) / 100 ) + tribeInfo.mod_vit;
-   m_baseStats.inte = base * ( static_cast< float >( classInfo.mod_int ) / 100 ) + tribeInfo.mod_int;
-   m_baseStats.mnd =  base * ( static_cast< float >( classInfo.mod_mnd ) / 100 ) + tribeInfo.mod_mnd;
-   m_baseStats.pie =  base * ( static_cast< float >( classInfo.mod_pie ) / 100 ) + tribeInfo.mod_pie;
+   m_baseStats.str =  static_cast< uint32_t >( base * ( static_cast< float >( classInfo.mod_str ) / 100 ) + tribeInfo.mod_str );
+   m_baseStats.dex =  static_cast< uint32_t >( base * ( static_cast< float >( classInfo.mod_dex ) / 100 ) + tribeInfo.mod_dex );
+   m_baseStats.vit =  static_cast< uint32_t >( base * ( static_cast< float >( classInfo.mod_vit ) / 100 ) + tribeInfo.mod_vit );
+   m_baseStats.inte = static_cast< uint32_t >( base * ( static_cast< float >( classInfo.mod_int ) / 100 ) + tribeInfo.mod_int );
+   m_baseStats.mnd =  static_cast< uint32_t >( base * ( static_cast< float >( classInfo.mod_mnd ) / 100 ) + tribeInfo.mod_mnd );
+   m_baseStats.pie =  static_cast< uint32_t >( base * ( static_cast< float >( classInfo.mod_pie ) / 100 ) + tribeInfo.mod_pie );
 
    m_baseStats.skillSpeed = paramGrowthInfo.base_secondary;
    m_baseStats.spellSpeed = paramGrowthInfo.base_secondary;
@@ -243,7 +243,7 @@ void Core::Entity::Player::calculateStats()
       m_hp = m_baseStats.max_hp;
 
 
-   m_baseStats.determination = base;
+   m_baseStats.determination = static_cast< uint32_t >( base );
 
 }
 
@@ -513,7 +513,7 @@ bool Core::Entity::Player::isAetheryteRegistered( uint8_t aetheryteId ) const
    uint8_t value;
    Util::valueToFlagByteIndexValue( aetheryteId, value, index );
 
-   return m_aetheryte[index] & value;
+   return ( m_aetheryte[index] & value ) != 0;
 }
 
 uint8_t * Core::Entity::Player::getDiscoveryBitmask()
@@ -608,7 +608,7 @@ bool Core::Entity::Player::isActionLearned( uint8_t actionId ) const
    uint8_t value;
    Util::valueToFlagByteIndexValue( actionId, value, index );
 
-   return m_unlocks[index] & value;
+   return ( m_unlocks[index] & value ) != 0;
 }
 
 void Core::Entity::Player::gainExp( uint32_t amount )
@@ -997,7 +997,7 @@ bool Core::Entity::Player::hasStateFlag( Core::Common::PlayerStateFlag flag ) co
    uint8_t value;
    Util::valueToFlagByteIndexValue( iFlag, value, index );
 
-   return m_stateFlags[index] & value;
+   return ( m_stateFlags[index] & value ) != 0;
 }
 
 void Core::Entity::Player::setStateFlag( Core::Common::PlayerStateFlag flag )
@@ -1463,7 +1463,7 @@ void Core::Entity::Player::autoAttack( ActorPtr pTarget )
    //uint64_t tick = Util::getTimeMs();
    //srand(static_cast< uint32_t >(tick));
 
-   uint32_t damage = mainWeap->getAutoAttackDmg();
+   uint32_t damage = static_cast< uint32_t >( mainWeap->getAutoAttackDmg() );
    uint32_t variation = 0 + rand() % 3;
 
    if ( getClass() == JOB_MACHINIST ||
@@ -1534,7 +1534,7 @@ void Core::Entity::Player::handleScriptSkill( uint32_t type, uint32_t actionId, 
       effectPacket.data().numEffects = 1;
       effectPacket.data().rotation = Math::Util::floatToUInt16Rot( getRotation() );
       effectPacket.data().effectTarget = pTarget.getId();
-      effectPacket.data().effects[0].param1 = param1;
+      effectPacket.data().effects[0].param1 = static_cast< int16_t >( param1 );
       effectPacket.data().effects[0].unknown_1 = 3;
       effectPacket.data().effects[0].unknown_2 = 1;
       effectPacket.data().effects[0].unknown_3 = 7;
@@ -1544,14 +1544,14 @@ void Core::Entity::Player::handleScriptSkill( uint32_t type, uint32_t actionId, 
       if ( !pTarget.isAlive() )
          break;
 
-      pTarget.takeDamage( param1 );
+      pTarget.takeDamage( static_cast< uint32_t >( param1 ) );
       pTarget.onActionHostile( shared_from_this() );
       break;
    }
 
    case Core::Common::HandleSkillType::StdHeal:
    {
-      uint32_t calculatedHeal = CalcBattle::calculateHealValue( getAsPlayer(), param1 );
+      uint32_t calculatedHeal = CalcBattle::calculateHealValue( getAsPlayer(), static_cast< uint32_t >( param1 ) );
 
       sendDebug( "STD_HEAL" );
 

--- a/src/servers/Server_Zone/Actor/PlayerEvent.cpp
+++ b/src/servers/Server_Zone/Actor/PlayerEvent.cpp
@@ -264,14 +264,14 @@ void Core::Entity::Player::onTick()
    if( !isAlive() || !isLoadingComplete() )
       return;
 
-   int32_t addHp = getMaxHp() * 0.1f + 1;
-   int32_t addMp = getMaxMp() * 0.06f + 1;
-   int32_t addTp = 100;
+   uint32_t addHp = static_cast< uint32_t >( getMaxHp() * 0.1f + 1 );
+   uint32_t addMp = static_cast< uint32_t >( getMaxMp() * 0.06f + 1 );
+   uint32_t addTp = 100;
 
    if( !m_actorIdTohateSlotMap.empty() )
    {
-      addHp = getMaxHp() * 0.01f + 1;
-      addMp = getMaxHp() * 0.02f + 1;
+      addHp = static_cast< uint32_t >( getMaxHp() * 0.01f + 1 );
+      addMp = static_cast< uint32_t >( getMaxMp() * 0.02f + 1 );
       addTp = 60;
    }
 

--- a/src/servers/Server_Zone/Actor/PlayerQuest.cpp
+++ b/src/servers/Server_Zone/Actor/PlayerQuest.cpp
@@ -74,7 +74,7 @@ bool Core::Entity::Player::loadActiveQuests()
 void Core::Entity::Player::finishQuest( uint16_t questId )
 {
 
-   int8_t idx = getQuestIndex( questId );
+   int8_t idx = getQuestIndex( static_cast< uint16_t >( questId ) );
 
    if( ( idx != -1 ) && ( m_activeQuests[idx] != nullptr ) )
    {
@@ -123,7 +123,7 @@ void Core::Entity::Player::unfinishQuest( uint16_t questId )
 void Core::Entity::Player::removeQuest( uint16_t questId )
 {
 
-   int8_t idx = getQuestIndex( questId );
+   int8_t idx = getQuestIndex( static_cast< uint16_t >( questId ) );
 
    if( ( idx != -1 ) && ( m_activeQuests[idx] != nullptr ) )
    {

--- a/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
@@ -109,7 +109,7 @@ void Core::Network::GameConnection::actionHandler( const Packets::GamePacket& in
         case 0x68: // Remove status (clicking it off)
         {
            // todo: check if status can be removed by client from exd
-           pPlayer->removeSingleStatusEffectFromId( param1 );
+           pPlayer->removeSingleStatusEffectFromId( static_cast< uint32_t >( param1 ) );
            break;
         }
         case 0x69: // Cancel cast

--- a/src/servers/Server_Zone/Script/ScriptManager.cpp
+++ b/src/servers/Server_Zone/Script/ScriptManager.cpp
@@ -346,7 +346,7 @@ bool Core::Scripting::ScriptManager::onMobKill( Entity::PlayerPtr pPlayer, uint1
    // loop through all active quests and try to call available onMobKill callbacks
    for( size_t i = 0; i < 30; i++ )
    {
-      auto activeQuests = pPlayer->getQuestActive( i );
+      auto activeQuests = pPlayer->getQuestActive( static_cast< uint16_t >( i ) );
       if( !activeQuests )
          continue;
 

--- a/src/servers/Server_Zone/ServerZone.cpp
+++ b/src/servers/Server_Zone/ServerZone.cpp
@@ -99,7 +99,7 @@ bool Core::ServerZone::loadSettings( int32_t argc, char* argv[] )
    }
 
    std::vector<std::string> args( argv + 1, argv + argc );
-   for( auto i = 0; i + 1 < args.size(); i += 2 )
+   for( uint32_t i = 0; i + 1 < args.size(); i += 2 )
    {
       std::string arg( "" );
       std::string val( "" );

--- a/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.cpp
+++ b/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.cpp
@@ -57,8 +57,8 @@ void Core::StatusEffect::StatusEffectContainer::addStatusEffect( StatusEffectPtr
    m_effectMap[nextSlot] = pEffect;
 
    GamePacketNew< Server::FFXIVIpcAddStatusEffect, ServerZoneIpcType > statusEffectAdd( m_pOwner->getId() );
-   statusEffectAdd.data().actor_id = m_pOwner->getId();
-   statusEffectAdd.data().actor_id1 = m_pOwner->getId();
+   statusEffectAdd.data().actor_id = pEffect->getTargetActorId();
+   statusEffectAdd.data().actor_id1 = pEffect->getSrcActorId(); 
    statusEffectAdd.data().current_hp = m_pOwner->getHp();
    statusEffectAdd.data().current_mp = m_pOwner->getMp();
    statusEffectAdd.data().current_tp = m_pOwner->getTp();
@@ -70,6 +70,7 @@ void Core::StatusEffect::StatusEffectContainer::addStatusEffect( StatusEffectPtr
    statusEffectAdd.data().max_something = 1;
     //statusEffectAdd.data().unknown2 = 28;
    statusEffectAdd.data().param = pEffect->getParam();
+
 
    bool sendToSelf = m_pOwner->isPlayer() ? true : false;
    m_pOwner->sendToInRangeSet( statusEffectAdd, sendToSelf );
@@ -142,8 +143,8 @@ void Core::StatusEffect::StatusEffectContainer::update()
 {
    uint64_t currentTimeMs = Util::getTimeMs();
 
-   uint64_t thisTickDmg = 0;
-   uint64_t thisTickHeal = 0;
+   uint32_t thisTickDmg = 0;
+   uint32_t thisTickHeal = 0;
 
    for( auto effectIt : m_effectMap )
    {

--- a/src/servers/Server_Zone/Zone/Zone.cpp
+++ b/src/servers/Server_Zone/Zone/Zone.cpp
@@ -189,7 +189,7 @@ void Zone::loadCellCache()
       Entity::BattleNpcPtr pBNpc( new Entity::BattleNpc( modelId, nameId, 
                                                          pos,
                                                          sizeId, type, level, behaviour, mobType ) );
-      pBNpc->setRotation( rotation );
+      pBNpc->setRotation( static_cast< float >( rotation ) );
       cache.push_back( pBNpc );
 
       //pushActor( pBNpc );


### PR DESCRIPTION
### Status effect source reference

Added an actor pointer param to the status effect adding procedures, so that we know the source actor for the status effects.

Status effects inflicted on other actors should now be green, as well as other implications for status when they get scripted (cover, etc).

![ffxiv_dx11_2017-09-15_00-17-15](https://user-images.githubusercontent.com/30917768/30465907-8ea96f70-99b0-11e7-8569-86df65b6835a.png)
![ffxiv_dx11_2017-09-15_00-20-00](https://user-images.githubusercontent.com/30917768/30465910-918330fa-99b0-11e7-93ec-fc9dd7c35be1.png)

### ActionCast battle log work

![ffxiv_dx11_2017-09-14_22-54-59](https://user-images.githubusercontent.com/30917768/30465937-be4e885a-99b0-11e7-9301-507bca717518.png)
![ffxiv_dx11_2017-09-14_22-54-46](https://user-images.githubusercontent.com/30917768/30465938-c3e9b938-99b0-11e7-96cb-3cd4aa25a114.png)

Still need to set up the proper aCtrl for cast finish, so that we can use the cast finish param (0x216, "You cast Cure.").
There also seems to be an odd behavior regarding packets being sent to other actors as well. Eg the cast cancel message doesn't really get sent to actors other than yourself.

### Cleaning compiler warnings up a bit

Static cast galore.

### Note on LeveStartError opcode

Seems to take params that reads off the error message, another one for reading the levequest's name (from leve.exh) and possibly another for the actor's location (unsure on this one).