### PR TITLE
Offset eorzea time

### DIFF
--- a/src/servers/Server_Common/Network/PacketDef/Ipcs.h
+++ b/src/servers/Server_Common/Network/PacketDef/Ipcs.h
@@ -116,6 +116,7 @@ namespace Packets {
       WeatherChange              = 0x01AF, // updated for sb
       Discovery                  = 0x01B2, // updated for sb
 
+      EorzeaTimeOffset           = 0x01B4,
 
       CFAvailableContents        = 0x01CF,
 

--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1281,6 +1281,11 @@ struct FFXIVIpcCFMemberStatus : FFXIVIpcBasePacket<CFMemberStatus>
    uint32_t unknown3;
 };
 
+struct FFXIVIpcEorzeaTimeOffset : FFXIVIpcBasePacket<EorzeaTimeOffset>
+{
+   uint64_t timestamp;
+};
+
 
 
 } /* Server */

--- a/src/servers/Server_Zone/Actor/Player.cpp
+++ b/src/servers/Server_Zone/Actor/Player.cpp
@@ -1668,3 +1668,14 @@ void Core::Entity::Player::setOpeningSequence( uint8_t seq )
    setSyncFlag( OpeningSeq );
    m_openingSequence = seq;
 }
+
+/// Tells client to offset their eorzean time by given timestamp.
+void Core::Entity::Player::setEorzeaTimeOffset( uint64_t timestamp )
+{
+   // TODO: maybe change to persistent?
+   GamePacketNew< FFXIVIpcEorzeaTimeOffset, ServerZoneIpcType > packet ( getId() );
+   packet.data().timestamp = timestamp;
+
+   // Send to single player
+   queuePacket( packet );
+}

--- a/src/servers/Server_Zone/Actor/Player.h
+++ b/src/servers/Server_Zone/Actor/Player.h
@@ -499,6 +499,10 @@ public:
 
    uint32_t getCFPenaltyMinutes() const;
    void setCFPenaltyMinutes( uint32_t minutes );
+
+   void setEorzeaTimeOffset( uint64_t timestamp );
+   
+
 private:
    uint32_t m_lastWrite;
    uint32_t m_lastPing;

--- a/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
+++ b/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
@@ -268,7 +268,7 @@ void Core::DebugCommandHandler::set( char * data, Core::Entity::PlayerPtr pPlaye
    else if ( subCommand == "eorzeatime" )
    {
       uint64_t timestamp;
-      sscanf(params.c_str(), "%llu", &timestamp);
+      sscanf( params.c_str(), "%llu", &timestamp );
 
       pPlayer->setEorzeaTimeOffset( timestamp );
       pPlayer->sendNotice( "Eorzea time offset: " + std::to_string( timestamp ) );

--- a/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
+++ b/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
@@ -40,7 +40,6 @@ extern Core::ServerZone g_serverZone;
 // instanciate and initialize commands
 Core::DebugCommandHandler::DebugCommandHandler()
 {
-
    // Push all commands onto the register map ( command name - function - description - required GM level )
    registerCommand( "set", &DebugCommandHandler::set, "Loads and injects a premade Packet.", 1 );
    registerCommand( "get", &DebugCommandHandler::get, "Loads and injects a premade Packet.", 1 );
@@ -213,8 +212,8 @@ void Core::DebugCommandHandler::set( char * data, Core::Entity::PlayerPtr pPlaye
 
    else if( ( subCommand == "unlockaetheryte" ) && ( params != "" ) )
    {
-	   for( uint8_t i = 0; i < 255; i++ )
-		   pPlayer->registerAetheryte( i );
+      for( uint8_t i = 0; i < 255; i++ )
+         pPlayer->registerAetheryte( i );
    }
 
    else if( ( subCommand == "discovery" ) && ( params != "" ) )

--- a/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
+++ b/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
@@ -254,17 +254,24 @@ void Core::DebugCommandHandler::set( char * data, Core::Entity::PlayerPtr pPlaye
    else if( subCommand == "aaah" )
    {
       int32_t id;
-
       sscanf( params.c_str(), "%d", &id );
+      
       pPlayer->sendDebug( std::to_string( pPlayer->actionHasCastTime( id ) ) );
    }
    else if ( subCommand == "cfpenalty" )
    {
       int32_t minutes;
-
       sscanf( params.c_str(), "%d", &minutes );
 
       pPlayer->setCFPenaltyMinutes( minutes );
+   }
+   else if ( subCommand == "eorzeatime" )
+   {
+      uint64_t timestamp;
+      sscanf(params.c_str(), "%llu", &timestamp);
+
+      pPlayer->setEorzeaTimeOffset( timestamp );
+      pPlayer->sendNotice( "Eorzea time offset: " + std::to_string( timestamp ) );
    }
 
 }


### PR DESCRIPTION
FFXIV 4.06
## ELI5
Opcode ```1B4``` is handled at ```ffxiv.exe + 0xAC357C``` which saves first 8 bytes of message to engine global variable.

This value will be later on the game loop at ```ffxiv.exe + 0x5B9FE8``` which makes a call to ```ffxiv.exe + 0x47E0E0``` to get desired eorzean time as long as does game doesn't want to use a fixed time instead.

## Usage
```@set eorzeatime value```

## Example
https://streamable.com/koi99

## Possible improvement
It's actually possible to replace ```@set eorzeatime``` command by ```//gm time value```
![2017-09-22 2](https://user-images.githubusercontent.com/1381835/30746293-4fc5cf6c-9fe4-11e7-981a-9f99676b6e69.png)

but then I'm too lazy to implement this so I'll dump this on to @AcedArmy 


