### PR TITLE
Player title prototype; Fix a few small issues;

### DIFF
--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -368,8 +368,8 @@ struct FFXIVIpcPlayerSpawn : FFXIVIpcBasePacket<PlayerSpawn>
    uint32_t u20;
    uint32_t ownerId;
    uint32_t u22;
-   uint32_t hPCurr;
    uint32_t hPMax;
+   uint32_t hPCurr;
    uint32_t displayFlags;
    uint16_t fateID;
    uint16_t mPCurr;

--- a/src/servers/Server_Zone/Action/ActionCast.cpp
+++ b/src/servers/Server_Zone/Action/ActionCast.cpp
@@ -92,7 +92,11 @@ void Core::Action::ActionCast::onInterrupt()
    m_pSource->getAsPlayer()->sendStateFlags();
 
    auto control = ActorControlPacket142( m_pSource->getId(), ActorControlType::CastInterrupt,
-                                          0x219, 1, m_id, 1 );
+                                          0x219, 1, m_id, 0 );
+
+   // Note: When cast interrupt from taking too much damage, set the last value to 1. This enables the cast interrupt effect. Example:
+   // auto control = ActorControlPacket142( m_pSource->getId(), ActorControlType::CastInterrupt, 0x219, 1, m_id, 0 );
+
    m_pSource->sendToInRangeSet( control, true );
 
 }

--- a/src/servers/Server_Zone/Actor/Actor.cpp
+++ b/src/servers/Server_Zone/Actor/Actor.cpp
@@ -696,9 +696,13 @@ void Core::Entity::Actor::handleScriptSkill( uint32_t type, uint32_t actionId, u
          if ( isPlayer() && !ActionCollision::isActorApplicable( pTarget.shared_from_this(), TargetFilter::Enemies ) )
             break;
 
-         pTarget.takeDamage( static_cast< uint32_t >( param1 ) );
-         pTarget.onActionHostile( shared_from_this() );
          sendToInRangeSet( effectPacket, true );
+
+         pTarget.takeDamage( static_cast< uint32_t >( param1 ) );
+
+         if ( pTarget.isAlive() )
+            pTarget.onActionHostile( shared_from_this() );
+         
       }
       else
       {
@@ -711,8 +715,11 @@ void Core::Entity::Actor::handleScriptSkill( uint32_t type, uint32_t actionId, u
             effectPacket.data().effectTarget = pHitActor->getId();
 
             sendToInRangeSet( effectPacket, true ); // todo: send to range of what? ourselves? when mob script hits this is going to be lacking
+
             pHitActor->takeDamage( static_cast< uint32_t >( param1 ) );
-            pHitActor->onActionHostile( shared_from_this() );
+
+            if( pHitActor->isAlive() )
+               pHitActor->onActionHostile( shared_from_this() );
 
             // Debug
             if ( isPlayer() ) 

--- a/src/servers/Server_Zone/Actor/Player.cpp
+++ b/src/servers/Server_Zone/Actor/Player.cpp
@@ -1415,7 +1415,7 @@ void Core::Entity::Player::setIsLogin( bool bIsLogin )
    m_bIsLogin = bIsLogin;
 }
 
-void Core::Entity::Player::setTitle( uint8_t titleId )
+void Core::Entity::Player::setTitle( uint16_t titleId )
 {
    m_title = titleId;
    sendToInRangeSet( ActorControlPacket142( getId(), SetTitle, titleId ), true );

--- a/src/servers/Server_Zone/Actor/Player.cpp
+++ b/src/servers/Server_Zone/Actor/Player.cpp
@@ -1415,6 +1415,12 @@ void Core::Entity::Player::setIsLogin( bool bIsLogin )
    m_bIsLogin = bIsLogin;
 }
 
+void Core::Entity::Player::setTitle( uint8_t titleId )
+{
+   m_title = titleId;
+   sendToInRangeSet( ActorControlPacket142( getId(), SetTitle, titleId ), true );
+}
+
 void Core::Entity::Player::autoAttack( ActorPtr pTarget )
 {
 

--- a/src/servers/Server_Zone/Actor/Player.h
+++ b/src/servers/Server_Zone/Actor/Player.h
@@ -329,7 +329,7 @@ public:
    /*! prepares zoning / fades out the screen */
    void prepareZoning( uint16_t targetZone, bool fadeOut, uint8_t fadoutTime = 0, uint16_t animation = 0 );
    /*! change player's title */
-   void setTitle( uint8_t titleId );
+   void setTitle( uint16_t titleId );
 
    void calculateStats() override;
    void sendStats();
@@ -567,8 +567,8 @@ private:
       uint8_t status;
    } m_retainerInfo[8];
 
-   uint8_t m_title;
-   uint8_t m_titleList[32];
+   uint16_t m_title;
+   uint16_t m_titleList[32];
    uint8_t m_achievement[16];
    uint8_t m_howTo[33];
    uint8_t m_homePoint;

--- a/src/servers/Server_Zone/Actor/Player.h
+++ b/src/servers/Server_Zone/Actor/Player.h
@@ -328,6 +328,8 @@ public:
    void teleport( uint16_t aetheryteId, uint8_t type = 1 );
    /*! prepares zoning / fades out the screen */
    void prepareZoning( uint16_t targetZone, bool fadeOut, uint8_t fadoutTime = 0, uint16_t animation = 0 );
+   /*! change player's title */
+   void setTitle( uint8_t titleId );
 
    void calculateStats() override;
    void sendStats();
@@ -565,6 +567,7 @@ private:
       uint8_t status;
    } m_retainerInfo[8];
 
+   uint8_t m_title;
    uint8_t m_titleList[32];
    uint8_t m_achievement[16];
    uint8_t m_howTo[33];

--- a/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
+++ b/src/servers/Server_Zone/DebugCommand/DebugCommandHandler.cpp
@@ -257,6 +257,13 @@ void Core::DebugCommandHandler::set( char * data, Core::Entity::PlayerPtr pPlaye
       pPlayer->sendModel();
       pPlayer->sendDebug( "Model updated" );
    }
+   else if ( subCommand == "title" )
+   {
+      uint32_t titleId;
+      sscanf( params.c_str(), "%d", &titleId );
+
+      pPlayer->setTitle( titleId );
+   }
    else
    {
       pPlayer->sendUrgent( subCommand + " is not a valid SET command." );

--- a/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/ActionHandler.cpp
@@ -114,7 +114,7 @@ void Core::Network::GameConnection::actionHandler( const Packets::GamePacket& in
         }
         case 0x69: // Cancel cast
         {
-           if( pPlayer->checkAction() )
+           if( pPlayer->getCurrentAction() != nullptr )
                pPlayer->getCurrentAction()->setInterrupted();
            break;
         }

--- a/src/servers/Server_Zone/Network/PacketWrappers/PlayerSpawnPacket.h
+++ b/src/servers/Server_Zone/Network/PacketWrappers/PlayerSpawnPacket.h
@@ -70,7 +70,7 @@ namespace Server {
 
          //m_data.u23 = 0x04;
          //m_data.u24 = 256;
-         m_data.state = (pPlayer->getHp() > 0) ? 1 : 2;
+         m_data.state = static_cast< uint8_t >( pPlayer->getStatus() );
          m_data.type = 1;
          if( pTarget == pPlayer )
          {

--- a/src/servers/Server_Zone/Network/PacketWrappers/PlayerSpawnPacket.h
+++ b/src/servers/Server_Zone/Network/PacketWrappers/PlayerSpawnPacket.h
@@ -70,7 +70,7 @@ namespace Server {
 
          //m_data.u23 = 0x04;
          //m_data.u24 = 256;
-         m_data.state = 1;
+         m_data.state = (pPlayer->getHp() > 0) ? 1 : 2;
          m_data.type = 1;
          if( pTarget == pPlayer )
          {


### PR DESCRIPTION
## Player title prototype ##

Initial implementation of the title system. Shouldn't require much effort from here.

![ffxiv_dx11_2017-10-04_23-17-30](https://user-images.githubusercontent.com/30917768/31208422-1de9a61e-a95b-11e7-9b3b-5f35668b90a0.png)

Moving forward from here:
* Implement title list. Add a method to player class that adds a title to the list, and then send the list to client when using the UI title select. Could do a few tests using a "!add title" command, and adding them through a random quest script.
* SQL. Fields for available title IDs, and current set title ID.

## Fix a few small issues ##

### Player spawn packet wasn't reflecting actual player state. ###

Fixes #70.

### Order for hpCurr/hPMax parameters on Player spawn packet were switched. ###
Wrong (Sapphire master 7abea43) - Notice max hp and hp values being inverted (and HP bar being displayed)

![waterfox_2017-10-04_23-39-48](https://user-images.githubusercontent.com/30917768/31208523-fe4b3c5e-a95b-11e7-8cad-c7ec98b9ace4.png)

Correct

![ffxiv_dx11_2017-10-04_21-12-13](https://user-images.githubusercontent.com/30917768/31208541-164dafa8-a95c-11e7-8ef8-0dd3fceb5736.png)

### Fix crash when spamming casted action and cast interrupt command while walking ###

Relying on pPlayer->checkAction() to check if an action exists is a bad idea due to the second responsibility of updating the action that the method has. It'd return true as it initially existed, but midway through resolve the action pointer to a nullptr. Perhaps an issue with method itself?

### Fix issue with aggro when mob dies instantly from skill; ###

On second thought it probably happened whenever you killed the mob.

Wrong (Sapphire master 7abea43) - Notice dead mobs showing up on aggro list

![i_view32_2017-10-04_23-43-49](https://user-images.githubusercontent.com/30917768/31208618-9c0ff6e6-a95c-11e7-9b88-1dcba6168c6f.png)

### Align cast interrupt ###

We were using cast interrupt packet for when you get hit by an enemy and your cast interrupts ("breaking" effect). No animation or effect is played when player manually interrupts cast.