### PR TITLE
Potential Truncation - value over signed char

### DIFF
--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -81,7 +81,7 @@ struct FFXIVIpcPlayTime : FFXIVIpcBasePacket<Playtime>
 */
 struct PlayerEntry {
    uint64_t contentId;
-   unsigned char bytes[12];
+   uint8_t bytes[12];
    uint16_t zoneId;
    uint16_t zoneId1;
    char bytes1[8];

--- a/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/servers/Server_Common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -81,7 +81,7 @@ struct FFXIVIpcPlayTime : FFXIVIpcBasePacket<Playtime>
 */
 struct PlayerEntry {
    uint64_t contentId;
-   char bytes[12];
+   unsigned char bytes[12];
    uint16_t zoneId;
    uint16_t zoneId1;
    char bytes1[8];


### PR DESCRIPTION
In PacketHandlers.cpp ~line453 - we are trying to insert a hex value
(128) x80 and will cause an underflow to -128.  Suggestion is to move to
unsigned char to capture the intended value.

```
listPacket.data().entries[0].bytes[3] = 0x80; // 128
```