### PR TITLE
 Correctly applying /ZI for debug

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -10,6 +10,10 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    # disabling SAFESEH
+    message(STATUS "Disabling Safe Exception Handlers..")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
+
     # edit and continue
     message(STATUS "Enabling Edit and Continue..")
     add_definitions(/ZI)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -9,10 +9,15 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
-  # edit and continue
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    # edit and continue
     message(STATUS "Enabling Edit and Continue..")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /INCREMENTAL /ZI")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZI")
+    add_definitions(/ZI)
+
+    # incremental linking
+    message(STATUS "Enabling Incremental Linking..")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /INCREMENTAL")
   endif()
 endif()
 

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -12,7 +12,6 @@ else()
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     # edit and continue
     message(STATUS "Enabling Edit and Continue..")
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZI")
     add_definitions(/ZI)
 
     # incremental linking


### PR DESCRIPTION
- /ZI is not a link flag
- /ZI is not settable via CMAKE_CXX_FLAGS
- /Zi is default unless add_defitions(/ZI)
- Need to disable SAFESEH before /ZI