### PR TITLE
Addressing unchecked iterator issues with core project

### DIFF
--- a/src/servers/Server_REST/main.cpp
+++ b/src/servers/Server_REST/main.cpp
@@ -597,7 +597,7 @@ int main(int argc, char* argv[])
 		   auto path = boost::filesystem::canonical( web_root_path / "news.xml" );
 		   //Check if path is within web_root_path
 		   if( distance( web_root_path.begin(), web_root_path.end() ) > distance( path.begin(), path.end() ) ||
-			   !equal( web_root_path.begin(), web_root_path.end(), path.begin() ) )
+			   !std::equal( web_root_path.begin(), web_root_path.end(), path.begin(), path.end() ) )
 			   throw invalid_argument( "path must be within root path" );
 		   if( !( boost::filesystem::exists( path ) && boost::filesystem::is_regular_file( path ) ) )
 			   throw invalid_argument( "file does not exist" );
@@ -638,7 +638,7 @@ int main(int argc, char* argv[])
 		   auto path = boost::filesystem::canonical( web_root_path / "headlines.xml" );
 		   //Check if path is within web_root_path
 		   if( distance( web_root_path.begin(), web_root_path.end() ) > distance( path.begin(), path.end() ) ||
-			   !equal( web_root_path.begin(), web_root_path.end(), path.begin() ) )
+			   !std::equal( web_root_path.begin(), web_root_path.end(), path.begin(), path.end() ) )
 			   throw invalid_argument( "path must be within root path" );
 		   if( !( boost::filesystem::exists( path ) && boost::filesystem::is_regular_file( path ) ) )
 			   throw invalid_argument( "file does not exist" );
@@ -683,7 +683,7 @@ int main(int argc, char* argv[])
          auto path = boost::filesystem::canonical( web_root_path / request->path );
          //Check if path is within web_root_path
          if( distance( web_root_path.begin(), web_root_path.end() ) > distance( path.begin(), path.end() ) ||
-             !equal( web_root_path.begin(), web_root_path.end(), path.begin() ) )
+             !std::equal( web_root_path.begin(), web_root_path.end(), path.begin(), path.end() ) )
             throw invalid_argument( "path must be within root path" );
          if( boost::filesystem::is_directory( path ) )
             path /= "index.html";

--- a/src/tools/exd_common_gen/CMakeLists.txt
+++ b/src/tools/exd_common_gen/CMakeLists.txt
@@ -27,6 +27,9 @@ if (UNIX)
   target_link_libraries (exd_common_gen Common xivdat pthread mysqlclient dl z)
 else()
   target_link_libraries (exd_common_gen Common xivdat libmysql zlib1)
+
+  # ignore unchecked iterators warnings from msvc
+  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 endif()
 
 target_link_libraries(exd_common_gen ${Boost_LIBRARIES} ${Boost_LIBRARIES})


### PR DESCRIPTION
- std::equal can take a 2nd iterator end
- use _SCL_SECURE_NO_WARNINGS for std::copy issues in exd_common_gen