### PR TITLE
Silence unchecked iterators for server_rest

### DIFF
--- a/src/servers/Server_REST/CMakeLists.txt
+++ b/src/servers/Server_REST/CMakeLists.txt
@@ -22,6 +22,9 @@ set_target_properties(server_rest PROPERTIES
 if (UNIX)
   target_link_libraries (server_rest Common xivdat pthread mysqlclient dl z)
 else()
+  # ignore unchecked iterators warnings from msvc
+  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+
   target_link_libraries (server_rest Common xivdat libmysql zlib1)
 endif()
 


### PR DESCRIPTION
- couldnt't find a better way to find the subpath or a root
- can't pass other iter length or it fails to view them as main and
subdir