### PR TITLE
Fix generated enum build break; Remove Mono as dependency from README;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sapphire - FINAL FANTASY XIV Server Emulator
+﻿# Sapphire - FINAL FANTASY XIV Server Emulator
 [![Discord Server](https://img.shields.io/badge/discord-Sapphire-7289DA.svg)](https://discord.gg/KfrZCkx)
 [![Linux Build Status](https://travis-ci.org/SapphireMordred/Sapphire.svg?branch=master)](https://travis-ci.org/SapphireMordred/Sapphire)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/lil7lxa3ty165emm?svg=true)](https://ci.appveyor.com/project/SapphireMordred/Sapphire)
@@ -16,7 +16,6 @@ Sapphire requires the following software:
 | CMake 2.6+ and C++14 capable compiler | [Visual Studio 2017](https://www.visualstudio.com/) | `gcc 4.9` and `g++ 4.9` or newer |
 | Boost 1.63.0 | [Win32 precompiled binaries](https://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-14.0-32.exe/download) | Boost libraries from your distribution's package manager |
 | MySQL Server 5.7 | [Official Site](https://dev.mysql.com/downloads/mysql/) | MySQL server from your distribution's package manager |
-| C# Compiler(used for various tools) | [Visual Studio 2017](https://www.visualstudio.com/) \| [Mono](http://www.mono-project.com/) | [Mono](http://www.mono-project.com/) from your distribution's package manager |
 
 **Windows**
 Set the environment variables ``BOOST_ROOT_DIR`` and ``BOOST_LIB_DIR`` to ``[boost main folder]`` and ``[boost main folder]/lib32-msvc-14.0`` respectively **or** copy your boost installation into the project's ``src/lib`` folder.

--- a/src/servers/Server_Common/CommonGen.cpp
+++ b/src/servers/Server_Common/CommonGen.cpp
@@ -1,5 +1,7 @@
 #include "CommonGen.h"
 
+#include <stdint.h>
+
 namespace Core {
 namespace Common {
 

--- a/src/servers/Server_Common/CommonGen.h
+++ b/src/servers/Server_Common/CommonGen.h
@@ -1,5 +1,8 @@
 #ifndef _COMMON_GEN_H_
 #define _COMMON_GEN_H_
+
+#include <stdint.h>
+
 /* This file has been automatically generated.
    Changes will be lost upon regeneration.
    To change the content edit tools/exd_common_gen */
@@ -26,8 +29,6 @@ namespace Common {
       ItemManipulation = 14,
       AdrenalineRush = 15,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //BeastReputationRank.exd
    enum class BeastReputationRank : uint8_t
@@ -42,14 +43,10 @@ namespace Common {
       Sworn = 7,
       Allied = 8,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //BeastTribe.exd
    enum class BeastTribe : uint8_t
    {
-
-   };
 
    ///////////////////////////////////////////////////////////
    //ClassJob.exd
@@ -92,8 +89,6 @@ namespace Common {
       Samurai = 34,
       Redmage = 35,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //ContentType.exd
    enum class ContentType : uint8_t
@@ -121,8 +116,6 @@ namespace Common {
       WondrousTails = 24,
       CustomDeliveries = 25,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //EmoteCategory.exd
    enum class EmoteCategory : uint8_t
@@ -130,8 +123,6 @@ namespace Common {
       General = 1,
       Persistent = 2,
       Expressions = 3,
-
-   };
 
    ///////////////////////////////////////////////////////////
    //ExVersion.exd
@@ -141,8 +132,6 @@ namespace Common {
       Heavensward = 1,
       Stormblood = 2,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //GrandCompany.exd
    enum class GrandCompany : uint8_t
@@ -151,8 +140,6 @@ namespace Common {
       Maelstrom = 1,
       OrderoftheTwinAdder = 2,
       ImmortalFlames = 3,
-
-   };
 
    ///////////////////////////////////////////////////////////
    //GuardianDeity.exd
@@ -170,8 +157,6 @@ namespace Common {
       NaldthaltheTraders = 10,
       NophicatheMatron = 11,
       AlthyktheKeeper = 12,
-
-   };
 
    ///////////////////////////////////////////////////////////
    //ItemUICategory.exd
@@ -278,8 +263,6 @@ namespace Common {
       FishersSecondaryTool = 99,
       Currency = 100,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //ItemSearchCategory.exd
    enum class ItemSearchCategory : uint8_t
@@ -370,8 +353,6 @@ namespace Common {
       RedMagesArms = 84,
       ScholarsArms = 85,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //OnlineStatus.exd
    enum class OnlineStatus : uint8_t
@@ -424,8 +405,6 @@ namespace Common {
       GrandCompany = 46,
       Online = 47,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //Race.exd
    enum class Race : uint8_t
@@ -436,8 +415,6 @@ namespace Common {
       Miqote = 4,
       Roegadyn = 5,
       AuRa = 6,
-
-   };
 
    ///////////////////////////////////////////////////////////
    //Tribe.exd
@@ -456,8 +433,6 @@ namespace Common {
       Raen = 11,
       Xaela = 12,
 
-   };
-
    ///////////////////////////////////////////////////////////
    //Town.exd
    enum class Town : uint8_t
@@ -468,8 +443,6 @@ namespace Common {
       Uldah = 3,
       Ishgard = 4,
       Kugane = 7,
-
-   };
 
    ///////////////////////////////////////////////////////////
    //Weather.exd
@@ -565,9 +538,6 @@ namespace Common {
       Thunder3 = 88,
       DimensionalDisruption3 = 89,
       FairSkies9 = 90,
-
-   };
-
 }
 }
 #endif

--- a/src/servers/Server_Common/CommonGen.h
+++ b/src/servers/Server_Common/CommonGen.h
@@ -28,6 +28,7 @@ namespace Common {
       Glamour = 13,
       ItemManipulation = 14,
       AdrenalineRush = 15,
+   };
 
    ///////////////////////////////////////////////////////////
    //BeastReputationRank.exd
@@ -42,11 +43,13 @@ namespace Common {
       Honored = 6,
       Sworn = 7,
       Allied = 8,
+   };
 
    ///////////////////////////////////////////////////////////
    //BeastTribe.exd
    enum class BeastTribe : uint8_t
    {
+   };
 
    ///////////////////////////////////////////////////////////
    //ClassJob.exd
@@ -88,6 +91,7 @@ namespace Common {
       Astrologian = 33,
       Samurai = 34,
       Redmage = 35,
+   };
 
    ///////////////////////////////////////////////////////////
    //ContentType.exd
@@ -115,6 +119,7 @@ namespace Common {
       DeepDungeons = 21,
       WondrousTails = 24,
       CustomDeliveries = 25,
+   };
 
    ///////////////////////////////////////////////////////////
    //EmoteCategory.exd
@@ -123,6 +128,7 @@ namespace Common {
       General = 1,
       Persistent = 2,
       Expressions = 3,
+   };
 
    ///////////////////////////////////////////////////////////
    //ExVersion.exd
@@ -131,6 +137,7 @@ namespace Common {
       ARealmReborn = 0,
       Heavensward = 1,
       Stormblood = 2,
+   };
 
    ///////////////////////////////////////////////////////////
    //GrandCompany.exd
@@ -140,6 +147,7 @@ namespace Common {
       Maelstrom = 1,
       OrderoftheTwinAdder = 2,
       ImmortalFlames = 3,
+   };
 
    ///////////////////////////////////////////////////////////
    //GuardianDeity.exd
@@ -157,6 +165,7 @@ namespace Common {
       NaldthaltheTraders = 10,
       NophicatheMatron = 11,
       AlthyktheKeeper = 12,
+   };
 
    ///////////////////////////////////////////////////////////
    //ItemUICategory.exd
@@ -262,6 +271,7 @@ namespace Common {
       ScholarsArm = 98,
       FishersSecondaryTool = 99,
       Currency = 100,
+   };
 
    ///////////////////////////////////////////////////////////
    //ItemSearchCategory.exd
@@ -352,6 +362,7 @@ namespace Common {
       SamuraisArms = 83,
       RedMagesArms = 84,
       ScholarsArms = 85,
+   };
 
    ///////////////////////////////////////////////////////////
    //OnlineStatus.exd
@@ -404,6 +415,7 @@ namespace Common {
       FreeCompany = 45,
       GrandCompany = 46,
       Online = 47,
+   };
 
    ///////////////////////////////////////////////////////////
    //Race.exd
@@ -415,6 +427,7 @@ namespace Common {
       Miqote = 4,
       Roegadyn = 5,
       AuRa = 6,
+   };
 
    ///////////////////////////////////////////////////////////
    //Tribe.exd
@@ -432,6 +445,7 @@ namespace Common {
       Hellsguard = 10,
       Raen = 11,
       Xaela = 12,
+   };
 
    ///////////////////////////////////////////////////////////
    //Town.exd
@@ -443,6 +457,7 @@ namespace Common {
       Uldah = 3,
       Ishgard = 4,
       Kugane = 7,
+   };
 
    ///////////////////////////////////////////////////////////
    //Weather.exd
@@ -538,6 +553,7 @@ namespace Common {
       Thunder3 = 88,
       DimensionalDisruption3 = 89,
       FairSkies9 = 90,
+   };
 }
 }
 #endif

--- a/src/servers/Server_REST/PlayerMinimal.cpp
+++ b/src/servers/Server_REST/PlayerMinimal.cpp
@@ -174,7 +174,7 @@ namespace Core {
       float x, y, z, o;
       int32_t startTown = 0;
 
-      switch( m_class )
+      switch( static_cast< Core::Common::ClassJob >( m_class ) )
       {
       case Core::Common::ClassJob::Conjurer:
       case Core::Common::ClassJob::Lancer:

--- a/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.cpp
+++ b/src/servers/Server_Zone/StatusEffect/StatusEffectContainer.cpp
@@ -48,7 +48,7 @@ Core::StatusEffect::StatusEffectContainer::~StatusEffectContainer()
 
 void Core::StatusEffect::StatusEffectContainer::addStatusEffect( StatusEffectPtr pEffect )
 {
-   uint8_t nextSlot = getFreeSlot();
+   int8_t nextSlot = getFreeSlot();
    // if there is no slot left, do not add the effect
    if( nextSlot == -1 )
       return;

--- a/src/tools/exd_common_gen/generated.h
+++ b/src/tools/exd_common_gen/generated.h
@@ -1,5 +1,9 @@
-[14:21:11][info] Setting up EXD data
-[14:21:12][info] /* This file has been automatically generated.
+#ifndef _COMMON_GEN_H_
+#define _COMMON_GEN_H_
+
+#include <stdint.h>
+
+/* This file has been automatically generated.
    Changes will be lost upon regeneration.
    To change the content edit tools/exd_common_gen */
 namespace Core {
@@ -7,7 +11,7 @@ namespace Common {
 
    ///////////////////////////////////////////////////////////
    //ActionCategory.exd
-   enum ActionCategory : uint8_t
+   enum class ActionCategory : uint8_t
    {
       Autoattack = 1,
       Spell = 2,
@@ -24,11 +28,10 @@ namespace Common {
       Glamour = 13,
       ItemManipulation = 14,
       AdrenalineRush = 15,
-   };
 
    ///////////////////////////////////////////////////////////
    //BeastReputationRank.exd
-   enum BeastReputationRank : uint8_t
+   enum class BeastReputationRank : uint8_t
    {
       None = 0,
       Neutral = 1,
@@ -39,25 +42,15 @@ namespace Common {
       Honored = 6,
       Sworn = 7,
       Allied = 8,
-   };
 
    ///////////////////////////////////////////////////////////
    //BeastTribe.exd
-   enum BeastTribe : uint8_t
+   enum class BeastTribe : uint8_t
    {
-      Amaljaa = 1,
-      Sylphs = 2,
-      Kobolds = 3,
-      Sahagin = 4,
-      Ixal = 5,
-      VanuVanu = 6,
-      Vath = 7,
-      Moogles = 8,
-   };
 
    ///////////////////////////////////////////////////////////
    //ClassJob.exd
-   enum ClassJob : uint8_t
+   enum class ClassJob : uint8_t
    {
       Adventurer = 0,
       Gladiator = 1,
@@ -95,11 +88,10 @@ namespace Common {
       Astrologian = 33,
       Samurai = 34,
       Redmage = 35,
-   };
 
    ///////////////////////////////////////////////////////////
    //ContentType.exd
-   enum ContentType : uint8_t
+   enum class ContentType : uint8_t
    {
       DutyRoulette = 1,
       Dungeons = 2,
@@ -122,39 +114,36 @@ namespace Common {
       GoldSaucer = 19,
       DeepDungeons = 21,
       WondrousTails = 24,
-   };
+      CustomDeliveries = 25,
 
    ///////////////////////////////////////////////////////////
    //EmoteCategory.exd
-   enum EmoteCategory : uint8_t
+   enum class EmoteCategory : uint8_t
    {
       General = 1,
       Persistent = 2,
       Expressions = 3,
-   };
 
    ///////////////////////////////////////////////////////////
    //ExVersion.exd
-   enum ExVersion : uint8_t
+   enum class ExVersion : uint8_t
    {
       ARealmReborn = 0,
       Heavensward = 1,
       Stormblood = 2,
-   };
 
    ///////////////////////////////////////////////////////////
    //GrandCompany.exd
-   enum GrandCompany : uint8_t
+   enum class GrandCompany : uint8_t
    {
       None = 0,
       Maelstrom = 1,
       OrderoftheTwinAdder = 2,
       ImmortalFlames = 3,
-   };
 
    ///////////////////////////////////////////////////////////
    //GuardianDeity.exd
-   enum GuardianDeity : uint8_t
+   enum class GuardianDeity : uint8_t
    {
       HalonetheFury = 1,
       MenphinatheLover = 2,
@@ -168,11 +157,10 @@ namespace Common {
       NaldthaltheTraders = 10,
       NophicatheMatron = 11,
       AlthyktheKeeper = 12,
-   };
 
    ///////////////////////////////////////////////////////////
    //ItemUICategory.exd
-   enum ItemUICategory : uint8_t
+   enum class ItemUICategory : uint8_t
    {
       PugilistsArm = 1,
       GladiatorsArm = 2,
@@ -273,11 +261,11 @@ namespace Common {
       RedMagesArm = 97,
       ScholarsArm = 98,
       FishersSecondaryTool = 99,
-   };
+      Currency = 100,
 
    ///////////////////////////////////////////////////////////
    //ItemSearchCategory.exd
-   enum ItemSearchCategory : uint8_t
+   enum class ItemSearchCategory : uint8_t
    {
       PrimaryArms = 1,
       PrimaryTools = 2,
@@ -364,11 +352,10 @@ namespace Common {
       SamuraisArms = 83,
       RedMagesArms = 84,
       ScholarsArms = 85,
-   };
 
    ///////////////////////////////////////////////////////////
    //OnlineStatus.exd
-   enum OnlineStatus : uint8_t
+   enum class OnlineStatus : uint8_t
    {
       Producer = 1,
       GameMaster = 2,
@@ -417,11 +404,10 @@ namespace Common {
       FreeCompany = 45,
       GrandCompany = 46,
       Online = 47,
-   };
 
    ///////////////////////////////////////////////////////////
    //Race.exd
-   enum Race : uint8_t
+   enum class Race : uint8_t
    {
       Hyur = 1,
       Elezen = 2,
@@ -429,11 +415,10 @@ namespace Common {
       Miqote = 4,
       Roegadyn = 5,
       AuRa = 6,
-   };
 
    ///////////////////////////////////////////////////////////
    //Tribe.exd
-   enum Tribe : uint8_t
+   enum class Tribe : uint8_t
    {
       Midlander = 1,
       Highlander = 2,
@@ -447,11 +432,10 @@ namespace Common {
       Hellsguard = 10,
       Raen = 11,
       Xaela = 12,
-   };
 
    ///////////////////////////////////////////////////////////
    //Town.exd
-   enum Town : uint8_t
+   enum class Town : uint8_t
    {
       Nowheresville = 0,
       LimsaLominsa = 1,
@@ -459,11 +443,10 @@ namespace Common {
       Uldah = 3,
       Ishgard = 4,
       Kugane = 7,
-   };
 
    ///////////////////////////////////////////////////////////
    //Weather.exd
-   enum Weather : uint8_t
+   enum class Weather : uint8_t
    {
       ClearSkies = 1,
       FairSkies = 2,
@@ -554,7 +537,8 @@ namespace Common {
       Quicklevin = 87,
       Thunder3 = 88,
       DimensionalDisruption3 = 89,
-   };
+      FairSkies9 = 90,
 }
 }
+#endif
 

--- a/src/tools/exd_common_gen/generated.h
+++ b/src/tools/exd_common_gen/generated.h
@@ -28,6 +28,7 @@ namespace Common {
       Glamour = 13,
       ItemManipulation = 14,
       AdrenalineRush = 15,
+   };
 
    ///////////////////////////////////////////////////////////
    //BeastReputationRank.exd
@@ -42,11 +43,13 @@ namespace Common {
       Honored = 6,
       Sworn = 7,
       Allied = 8,
+   };
 
    ///////////////////////////////////////////////////////////
    //BeastTribe.exd
    enum class BeastTribe : uint8_t
    {
+   };
 
    ///////////////////////////////////////////////////////////
    //ClassJob.exd
@@ -88,6 +91,7 @@ namespace Common {
       Astrologian = 33,
       Samurai = 34,
       Redmage = 35,
+   };
 
    ///////////////////////////////////////////////////////////
    //ContentType.exd
@@ -115,6 +119,7 @@ namespace Common {
       DeepDungeons = 21,
       WondrousTails = 24,
       CustomDeliveries = 25,
+   };
 
    ///////////////////////////////////////////////////////////
    //EmoteCategory.exd
@@ -123,6 +128,7 @@ namespace Common {
       General = 1,
       Persistent = 2,
       Expressions = 3,
+   };
 
    ///////////////////////////////////////////////////////////
    //ExVersion.exd
@@ -131,6 +137,7 @@ namespace Common {
       ARealmReborn = 0,
       Heavensward = 1,
       Stormblood = 2,
+   };
 
    ///////////////////////////////////////////////////////////
    //GrandCompany.exd
@@ -140,6 +147,7 @@ namespace Common {
       Maelstrom = 1,
       OrderoftheTwinAdder = 2,
       ImmortalFlames = 3,
+   };
 
    ///////////////////////////////////////////////////////////
    //GuardianDeity.exd
@@ -157,6 +165,7 @@ namespace Common {
       NaldthaltheTraders = 10,
       NophicatheMatron = 11,
       AlthyktheKeeper = 12,
+   };
 
    ///////////////////////////////////////////////////////////
    //ItemUICategory.exd
@@ -262,6 +271,7 @@ namespace Common {
       ScholarsArm = 98,
       FishersSecondaryTool = 99,
       Currency = 100,
+   };
 
    ///////////////////////////////////////////////////////////
    //ItemSearchCategory.exd
@@ -352,6 +362,7 @@ namespace Common {
       SamuraisArms = 83,
       RedMagesArms = 84,
       ScholarsArms = 85,
+   };
 
    ///////////////////////////////////////////////////////////
    //OnlineStatus.exd
@@ -404,6 +415,7 @@ namespace Common {
       FreeCompany = 45,
       GrandCompany = 46,
       Online = 47,
+   };
 
    ///////////////////////////////////////////////////////////
    //Race.exd
@@ -415,6 +427,7 @@ namespace Common {
       Miqote = 4,
       Roegadyn = 5,
       AuRa = 6,
+   };
 
    ///////////////////////////////////////////////////////////
    //Tribe.exd
@@ -432,6 +445,7 @@ namespace Common {
       Hellsguard = 10,
       Raen = 11,
       Xaela = 12,
+   };
 
    ///////////////////////////////////////////////////////////
    //Town.exd
@@ -443,6 +457,7 @@ namespace Common {
       Uldah = 3,
       Ishgard = 4,
       Kugane = 7,
+   };
 
    ///////////////////////////////////////////////////////////
    //Weather.exd
@@ -538,6 +553,7 @@ namespace Common {
       Thunder3 = 88,
       DimensionalDisruption3 = 89,
       FairSkies9 = 90,
+   };
 }
 }
 #endif

--- a/src/tools/exd_common_gen/main.cpp
+++ b/src/tools/exd_common_gen/main.cpp
@@ -71,9 +71,10 @@ std::string generateEnum( const std::string& exd, int8_t nameIndex, const std::s
    result +=
            "      bool operator==( const " + exd + "& t, const " + type + "& g ) { return static_cast< " + type + " >( t ) == g; }\n"
            "      bool operator==( const " + type + "& g, const " + exd + "& t ) { return static_cast< " + type + " >( t ) == g; }\n";
+   */
+
    result += "   };\n";
 
-   */
    return result;
 
 }

--- a/src/tools/exd_common_gen/main.cpp
+++ b/src/tools/exd_common_gen/main.cpp
@@ -21,7 +21,7 @@ Core::Data::ExdData g_exdData;
 
 
 //const std::string datLocation( "/opt/sapphire_3_15_0/bin/sqpack" );
-const std::string datLocation( "C:\\SquareEnix\\FINAL FANTASY XIV - A Realm Reborn\\game\\sqpack\\ffxiv" );
+const std::string datLocation( "C:\\Data\\Games\\Final Fantasy XIV\\SquareEnix\\FINAL FANTASY XIV - A Realm Reborn\\game\\sqpack\\ffxiv" );
 
 std::string generateEnum( const std::string& exd, int8_t nameIndex, const std::string& type, bool useLang = true )
 {
@@ -46,7 +46,7 @@ std::string generateEnum( const std::string& exd, int8_t nameIndex, const std::s
       auto test = boost::get< std::string >( &fields.at( nameIndex ) );
       if( !test )
          continue;
-      auto str = *test ;
+      auto str = *test;
       str.erase( boost::remove_if( str, boost::is_any_of(",_-':!(){} \x02\x1f\x01\x03") ), str.end() );
       if( str.empty() )
          continue;
@@ -66,11 +66,14 @@ std::string generateEnum( const std::string& exd, int8_t nameIndex, const std::s
       result += "      " + str + " = " + std::to_string( id  ) + ",\n";
 
    }
+
+   /*
    result +=
            "      bool operator==( const " + exd + "& t, const " + type + "& g ) { return static_cast< " + type + " >( t ) == g; }\n"
            "      bool operator==( const " + type + "& g, const " + exd + "& t ) { return static_cast< " + type + " >( t ) == g; }\n";
    result += "   };\n";
 
+   */
    return result;
 
 }
@@ -85,10 +88,12 @@ int main()
    if( !g_exdData.init( datLocation  ) )
    {
       g_log.fatal( "Error setting up EXD data " );
-      return 0;
+      return 1;
    }
   
    std::string result = "#ifndef _COMMON_GEN_H_\n#define _COMMON_GEN_H_\n";
+
+   result += "\n#include <stdint.h>\n\n";
 
    result +=
    "/* This file has been automatically generated.\n   Changes will be lost upon regeneration.\n   To change the content edit tools/exd_common_gen */\n";


### PR DESCRIPTION
## Fix generated enum build break ##

Include stdint.h so we can have the type aliases needed (mostly uint8_t)

## Remove Mono as dependency from README ##

None of the tools in this repository depend on a C# runtime.