### PR TITLE
Update Travis config for faster builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ src/servers/Server_Common/Version\.cpp
 
 # edit and continue files
 /enc_temp_folder
+
+# travis-ci build mtime cache
+.mtime_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,44 @@
+---
 language: c++
-sudo: enabled
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository universe
-  - sudo apt-get update 
-  - sudo apt-get install -y software-properties-common
-  - sudo apt-get update
-  - sudo apt-get install gcc-7 g++-7 gcc-7-multilib g++-7-multilib cmake3 -y
-  - sudo apt-get install libboost-dev libboost-all-dev libmysqlclient-dev -y
-  - sudo apt-get install libmysqlcppconn-dev -y
 
-compiler:
-  - g++
-  
- 
+sudo: enabled
+
+git:
+  depth: 5
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+# Setup cache
+cache:
+  directories:
+    - build
+    - .mtime_cache
+
+# Setup build matrix and dependencies
+before_install:
+  - eval "${MATRIX_EVAL}"
+  - gem install --no-ri --no-rdoc mtime_cache
+  - sudo apt-get update
+  - sudo apt-get install -y libboost-dev libboost-all-dev
+  - sudo apt-get install -y libmysqlclient-dev libmysqlcppconn-dev
+
 # Build steps
 script:
-  - g++ --version
-  - mkdir build
+  - $CXX --version
+  - mtime_cache src/**/*.{%{cpp}} -c .mtime_cache/cache.json
+  - mkdir -p build
   - cd build
-  - cmake .. -DSAPPHIRE_BOOST_VER="1.54.0" -DCMAKE_CXX_COMPILER=g++-7 && make -j 3
+  - cmake .. -DSAPPHIRE_BOOST_VER="1.54.0" && make -j 3
   - cd ..
   - bash sql_import.sh


### PR DESCRIPTION
Setup a proper build matrix. Dependencies of the buildchain vs the build itself are split up; more stuff in parallel should be faster.

I'd like to not need the extra compiler installs at all but Travis uses 14.04 which is almost 4 years old and somewhat out of date so we need something more modern for C++11/14/17 support according to Travis docs. This may not actually be the case but someone would need to check which features we user and if the default `g++` supports them.

The `software-properties-common` dependency isn't really needed unless I've missed one of the tools. CMake was removed as a dependency since Trusty comes with 3.2 and our update only installs 3.5, while the project minimum is 2.6 currently and aim to upgrade to 3.1.

Add support for mtime_cache, a small Ruby gem for hashing file mtime and automatically updating unchanged files so that CMake knows which cached build files are still valid since Git doesn't track mtime.

For changes to things like config files, this shaves off up to 4 minutes from the build. Dependency resolution is still the slowest part and I only managed to take ~20s off it, and that's unlikely to get any better.

![buildtimes](https://user-images.githubusercontent.com/28627120/33232598-04d2de54-d25d-11e7-99a4-26b3b403e88e.png)