### PR TITLE
Add a more windows-friendly SQL import script

### DIFF
--- a/sql/import.bat
+++ b/sql/import.bat
@@ -1,0 +1,48 @@
+@ECHO OFF
+SETLOCAL
+REM =============
+REM IMPORT CONFIG
+REM =============
+REM NOTE: No spaces before or after the '='!!!
+
+REM =============
+SET PATH_MYSQL="Path\to\mysql.exe"
+SET PATH_MYSQLADMIN="Path\to\mysqladmin.exe"
+SET PATH_SQL="Path\to\Sapphire\sql"
+
+SET USER=root
+SET PASSWORD=
+SET DBADDRESS=localhost
+SET DBPORT=3306
+SET DBNAME=sapphire
+REM =============
+
+IF DEFINED PASSWORD (SET PASSWORD=-p%PASSWORD%)
+
+ECHO Deleteing old database
+%PATH_MYSQLADMIN% -h %DBADDRESS% -u %USER% %PASSWORD% DROP %DBNAME%
+
+ECHO Creating new database
+%PATH_MYSQLADMIN% -h %DBADDRESS% -u %USER% %PASSWORD% CREATE %DBNAME%
+
+ECHO Loading tables into the database
+cd %PATH_SQL%
+FOR %%X IN (*.sql) DO (
+	IF "%%X"=="update.sql" (
+		REM handle update.sql last
+	) ELSE (
+		ECHO Importing %%X
+		%PATH_MYSQL% %DBNAME% -h %DBADDRESS% -u %USER% < %%X
+	)
+)
+
+IF EXIST "update.sql" (
+	ECHO Importing update.sql
+	%PATH_MYSQL% %DBNAME% -h %DBADDRESS% -u %USER% < update.sql
+)
+
+ECHO Finished!
+
+ENDLOCAL
+PAUSE
+@ECHO ON


### PR DESCRIPTION
Script based off the import.sql from FFXIV Classic. Uses Windows-friendly batch scripting and paths so users can just adjust the file to their environment and run to import/reimport a fresh database. It will always run the update.sql file last to prevent any conflicts while importing.