### PR TITLE
Add VS2017 generator definitions

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -56,6 +56,62 @@
           "value": "-vc140"
         }
       ]
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Debug",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "-DCMAKE_BUILD_TYPE=\"Debug\"",
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc141"
+        }
+      ]
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Visual Studio 15 2017",
+      "configurationType": "Release",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc141"
+        }
+      ]
+    },
+    {
+      "name": "x64-Debug",
+      "generator": "Visual Studio 15 2017 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "-DCMAKE_BUILD_TYPE=\"Debug\"",
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc141"
+        }
+      ]
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Visual Studio 15 2017 Win64",
+      "configurationType": "Release",
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuild\\${workspaceHash}\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-m -v:minimal",
+      "variables": [
+        {
+          "name": "Boost_COMPILER",
+          "value": "-vc141"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
People are asking for help in `#troubleshooting` every other day for CMake issues in VS2017. This PR adds a generator definition with a slightly bumped compiler version for Boost so there should be no more need for silly CLI flags or other workarounds. Built-in CMake should work just fine too. Tested by @GokuWeedLord.