### PR TITLE
Perform fix

### DIFF
--- a/src/servers/Server_Common/Network/GamePacket.h
+++ b/src/servers/Server_Common/Network/GamePacket.h
@@ -45,31 +45,37 @@ public:
    template<class T>
    T getValAt( uint16_t pos ) const
    {
-      assert(m_segHdr.size > pos);
+      assert( m_segHdr.size > pos );
       return *reinterpret_cast< const T* >( &m_dataBuf[0] + pos );
    }
 
    void setBytesAt( uint16_t offset, uint8_t * bytes, uint16_t length )
    {
-      assert(m_segHdr.size > offset);
+      assert( m_segHdr.size > offset );
       memcpy( reinterpret_cast< uint8_t* >( &m_dataBuf[0] + offset ), bytes, length );
    }
 
    const char * getStringAt( uint16_t pos ) const
    {
-      assert(m_segHdr.size > pos);
+      assert( m_segHdr.size > pos );
       return reinterpret_cast< const char* >( &m_dataBuf[0] + pos );
    }
 
    void setStringAt( uint16_t pos, const std::string& str )
    {
-      assert(m_segHdr.size > pos);
+      assert( m_segHdr.size > pos );
       memcpy( reinterpret_cast< uint8_t* >( &m_dataBuf[0] + pos ), str.c_str(), str.length() );
    }
 
-   uint8_t * getData()
+   const uint8_t * getData() const
    {
-      return reinterpret_cast< uint8_t* >( &m_dataBuf[0] );
+      return reinterpret_cast< const uint8_t* >( &m_dataBuf[0] );
+   }
+
+   const uint8_t * getDataAt(uint16_t pos) const
+   {
+      assert(m_segHdr.size > pos);
+      return reinterpret_cast< const uint8_t* >(&m_dataBuf[0] + pos);
    }
 
    void setHeader( uint16_t size, uint16_t type, uint32_t id1, uint32_t id2, uint16_t subType, uint32_t unknown = 0xFED2E000 );

--- a/src/servers/Server_Common/Network/GamePacket.h
+++ b/src/servers/Server_Common/Network/GamePacket.h
@@ -74,8 +74,8 @@ public:
 
    const uint8_t * getDataAt(uint16_t pos) const
    {
-      assert(m_segHdr.size > pos);
-      return reinterpret_cast< const uint8_t* >(&m_dataBuf[0] + pos);
+      assert( m_segHdr.size > pos );
+      return reinterpret_cast< const uint8_t* >( &m_dataBuf[0] + pos );
    }
 
    void setHeader( uint16_t size, uint16_t type, uint32_t id1, uint32_t id2, uint16_t subType, uint32_t unknown = 0xFED2E000 );

--- a/src/servers/Server_Zone/Network/Handlers/PacketHandlers.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/PacketHandlers.cpp
@@ -601,7 +601,7 @@ void Core::Network::GameConnection::tellHandler( const Packets::GamePacket& inPa
 void Core::Network::GameConnection::performNoteHandler( const Packets::GamePacket& inPacket,
                                                         Entity::Player& player )
 {
-   GamePacketNew< FFXIVIpcPerformNote, ServerZoneIpcType > performPacket( player.getId() );
+   ZoneChannelPacket< FFXIVIpcPerformNote > performPacket( player.getId() );
 
    auto inVal = inPacket.getDataAt( 0x20 );
    memcpy( &performPacket.data().data[0], inVal, 32 );

--- a/src/servers/Server_Zone/Network/Handlers/PacketHandlers.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/PacketHandlers.cpp
@@ -603,7 +603,7 @@ void Core::Network::GameConnection::performNoteHandler( const Packets::GamePacke
 {
    GamePacketNew< FFXIVIpcPerformNote, ServerZoneIpcType > performPacket( player.getId() );
 
-   auto inVal = inPacket.getDataAt(0x20);
+   auto inVal = inPacket.getDataAt( 0x20 );
    memcpy( &performPacket.data().data[0], inVal, 32 );
 
    player.sendToInRangeSet( performPacket );

--- a/src/servers/Server_Zone/Network/Handlers/PacketHandlers.cpp
+++ b/src/servers/Server_Zone/Network/Handlers/PacketHandlers.cpp
@@ -603,8 +603,8 @@ void Core::Network::GameConnection::performNoteHandler( const Packets::GamePacke
 {
    GamePacketNew< FFXIVIpcPerformNote, ServerZoneIpcType > performPacket( player.getId() );
 
-   uint8_t inVal = inPacket.getValAt< uint8_t >( 0x20 );
-   memcpy( &performPacket.data().data[0], &inVal, 32 );
+   auto inVal = inPacket.getDataAt(0x20);
+   memcpy( &performPacket.data().data[0], inVal, 32 );
 
    player.sendToInRangeSet( performPacket );
 }


### PR DESCRIPTION
I falsely assumed that [getDataAt](https://github.com/perize/Sapphire/blob/0fa3f93ce901ca59fb26fc94ae6f1652c16996ea/src/servers/Server_Common/Network/GamePacket.h#L46) would return a value which I could just cast it to the pointer to get an address of the packet data.

But nope, @itsMaru pointed out that perform does not work on Sapphire and sends some uninitialized memory.

Client sent:
![Client sent](https://user-images.githubusercontent.com/32560987/33792455-37000920-dce3-11e7-8c45-0e3a3a80c50b.png)

Response, note that 0xCC is not supposed to be happen here.
![Server packet](https://user-images.githubusercontent.com/32560987/33792456-3727c1b8-dce3-11e7-8e2a-6fee8d80e011.png)

This PR fix should fix it.