### PR TITLE
fix itemlevel calculation being incorrect

### DIFF
--- a/src/servers/Server_Zone/Inventory/Inventory.cpp
+++ b/src/servers/Server_Zone/Inventory/Inventory.cpp
@@ -884,7 +884,7 @@ uint16_t Core::Inventory::calculateEquippedGearItemLevel()
       it++;
    }
 
-   return boost::algorithm::clamp( iLvlResult / 12, 0, 9999 );
+   return boost::algorithm::clamp( iLvlResult / 13, 0, 9999 );
 }
 
 


### PR DESCRIPTION
should always be divided by 13 instead of 12

6 armour slots + 5 accessory slots + 2 weapon slots - weapon is counted twice in the event that a 2 handed weapon is equipped