### PR TITLE
Fix boost static lib cmake find (experimental)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,13 @@ set( LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/libraries" )
 
 ##########################################################################
 # Dependencies and compiler settings
-#include( "cmake/boost.cmake" )
+
+if( NOT SAPPHIRE_BOOST_VER )
+    set( SAPPHIRE_BOOST_VER 1.63.0 )
+endif()
+set( SAPPHIRE_BOOST_FOLDER_NAME boost_1_63_0 )
+
+include( "cmake/boost.cmake" )
 #include( "cmake/mysql.cmake" )
 include( "cmake/compiler.cmake" )
 include( "cmake/cotire.cmake" )

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -67,7 +67,7 @@
       "variables": [
         {
           "name": "Boost_COMPILER",
-          "value": "-vc141"
+          "value": "-vc140"
         }
       ]
     },
@@ -81,7 +81,7 @@
       "variables": [
         {
           "name": "Boost_COMPILER",
-          "value": "-vc141"
+          "value": "-vc140"
         }
       ]
     },
@@ -95,7 +95,7 @@
       "variables": [
         {
           "name": "Boost_COMPILER",
-          "value": "-vc141"
+          "value": "-vc140"
         }
       ]
     },
@@ -109,7 +109,7 @@
       "variables": [
         {
           "name": "Boost_COMPILER",
-          "value": "-vc141"
+          "value": "-vc140"
         }
       ]
     }


### PR DESCRIPTION
our boost cmake module used variables that were not set beforehand, plus our boost version only supplied static libs for vc140 toolkit and thus could not find them due to naming

a suggestion would be checking on our cmake boost module to check if the variable was set, and warn beforehand