### PR TITLE
Fix packet object slicing;

### DIFF
--- a/src/common/Forwards.h
+++ b/src/common/Forwards.h
@@ -24,8 +24,10 @@ namespace Core
       namespace Packets
       {
          class GamePacket;
+         class FFXIVPacketBase;
 
          typedef boost::shared_ptr< GamePacket > GamePacketPtr;
+         typedef boost::shared_ptr< FFXIVPacketBase > FFXIVPacketBasePtr;
       }
 
    }

--- a/src/common/Network/GamePacketNew.h
+++ b/src/common/Network/GamePacketNew.h
@@ -80,6 +80,7 @@ public:
 
    virtual std::vector< uint8_t > getData() const
    {
+      std::cout << "konichiwa bitches" << std::endl;
       return {};
    }
 

--- a/src/common/Network/GamePacketNew.h
+++ b/src/common/Network/GamePacketNew.h
@@ -80,7 +80,6 @@ public:
 
    virtual std::vector< uint8_t > getData() const
    {
-      std::cout << "konichiwa bitches" << std::endl;
       return {};
    }
 

--- a/src/common/Network/PacketContainer.cpp
+++ b/src/common/Network/PacketContainer.cpp
@@ -1,6 +1,7 @@
 #include "PacketContainer.h"
 
 #include "Common.h"
+#include "Forwards.h"
 
 #include <boost/format.hpp>
 
@@ -19,11 +20,11 @@ Core::Network::Packets::PacketContainer::~PacketContainer()
    m_entryList.clear();
 }
 
-void Core::Network::Packets::PacketContainer::addPacket( FFXIVPacketBase entry )
+void Core::Network::Packets::PacketContainer::addPacket( Core::Network::Packets::FFXIVPacketBasePtr entry )
 {
    m_entryList.push_back( entry );
 
-   m_ipcHdr.size += entry.getSize();
+   m_ipcHdr.size += entry->getSize();
    m_ipcHdr.count++;
 }
 
@@ -50,9 +51,9 @@ void Core::Network::Packets::PacketContainer::fillSendBuffer( std::vector< uint8
 
    for( ; it != m_entryList.end(); ++it )
    {
-      auto data = it->getData();
-      memcpy( &tempBuffer[0] + sizeof( FFXIVARR_PACKET_HEADER ) + offset, &data[0], it->getSize() );
-      offset += it->getSize();
+      auto data = (*it)->getData();
+      memcpy( &tempBuffer[0] + sizeof( FFXIVARR_PACKET_HEADER ) + offset, &data[0], (*it)->getSize() );
+      offset += (*it)->getSize();
    }
 
    sendBuffer.assign( &tempBuffer[0], &tempBuffer[0] + m_ipcHdr.size );

--- a/src/common/Network/PacketContainer.h
+++ b/src/common/Network/PacketContainer.h
@@ -19,11 +19,11 @@ public:
    PacketContainer();
    ~PacketContainer();
 
-   void addPacket( FFXIVPacketBase entry );
+   void addPacket( FFXIVPacketBasePtr entry );
 
    FFXIVARR_PACKET_HEADER m_ipcHdr;
 
-   std::vector< FFXIVPacketBase > m_entryList;
+   std::vector< FFXIVPacketBasePtr > m_entryList;
 
    std::string toString();
 

--- a/src/servers/sapphire_zone/Network/GameConnection.cpp
+++ b/src/servers/sapphire_zone/Network/GameConnection.cpp
@@ -303,7 +303,7 @@ void Core::Network::GameConnection::processOutQueue()
          break;
       }
 
-      pRP.addPacket( *pPacket );
+      pRP.addPacket( pPacket );
       totalSize += pPacket->getSize();
    }
 
@@ -315,7 +315,7 @@ void Core::Network::GameConnection::processOutQueue()
 void Core::Network::GameConnection::sendSinglePacket( Core::Network::Packets::FFXIVPacketBasePtr pPacket )
 {
    PacketContainer pRP = PacketContainer();
-   pRP.addPacket( *pPacket );
+   pRP.addPacket( pPacket );
    sendPackets( &pRP );
 }
 


### PR DESCRIPTION
vector in PacketContainer was handling base packet type, thus slicing down any derived object to the base.
handling packets in the container and dereferencing them calls the correct derived functions in the vtable

though, we may want to rethink our container if the pointer not being there was thought of and was intended