### PR TITLE
Fixed Tell and add research I found for u3b in tell struct

### DIFF
--- a/src/common/Network/PacketDef/Chat/ServerChatDef.h
+++ b/src/common/Network/PacketDef/Chat/ServerChatDef.h
@@ -20,7 +20,7 @@ struct FFXIVIpcTell : FFXIVIpcBasePacket<Tell>
    uint16_t u2b;
    uint8_t preName;
    uint8_t u3a;
-   uint8_t u3b;
+   uint8_t u3b; //Setting this to 1 seems to mark the tell as a GM tell (More research needed)
    char receipientName[32];
    char msg[1031];
 };

--- a/src/servers/sapphire_zone/Network/Handlers/PacketHandlers.cpp
+++ b/src/servers/sapphire_zone/Network/Handlers/PacketHandlers.cpp
@@ -565,8 +565,8 @@ void Core::Network::GameConnection::logoutHandler( const Packets::GamePacket& in
 void Core::Network::GameConnection::tellHandler( const Packets::GamePacket& inPacket,
                                                  Entity::Player& player )
 {
-   std::string targetPcName = inPacket.getStringAt( 0x21 );
-   std::string msg = inPacket.getStringAt( 0x41 );
+   std::string targetPcName = inPacket.getStringAt( 0x24 );
+   std::string msg = inPacket.getStringAt( 0x44 );
 
    auto pZoneServer = g_fw.get< ServerZone >();
 


### PR DESCRIPTION
- Fixed tells not working by changing the location we look in the packet for the playername and message

- I also noticed if you set u3b to 1 it marks the tell as a gm tell but only set to 1 from my little testing