### PR TITLE
Correctly initialize m_targetId in Chara

### DIFF
--- a/src/servers/sapphire_zone/Actor/Chara.cpp
+++ b/src/servers/sapphire_zone/Actor/Chara.cpp
@@ -34,7 +34,8 @@ using namespace Core::Network::Packets::Server;
 using namespace Core::Network::ActorControl;
 
 Core::Entity::Chara::Chara( ObjKind type ) :
-   Actor( type )
+   Actor( type ),
+   m_targetId( INVALID_GAME_OBJECT_ID )
 {
    // initialize the free slot queue
    for( uint8_t i = 0; i < MAX_STATUS_EFFECTS; i++ )


### PR DESCRIPTION
This fixes the target of selected players appearing as "???" until they target something for themselves