### PR TITLE
Opening + char create items (fixes #356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sapphire requires the following software:
 
 | *Name* | *Windows* | *Linux* |
 | ------ | --------- | ------- |
-| CMake 2.6+ and C++14 capable compiler | [Visual Studio 2017](https://www.visualstudio.com/) | `gcc 4.9` and `g++ 4.9` or newer |
+| CMake 3.0.2+ and C++14 capable compiler | [Visual Studio 2017](https://www.visualstudio.com/) | `gcc 4.9` and `g++ 4.9` or newer |
 | Boost 1.63.0 | [Win32 precompiled binaries](https://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-14.0-32.exe/download) | Boost libraries from your distribution's package manager |
 | MySQL Server 5.7 | [Official Site](https://dev.mysql.com/downloads/mysql/) | MySQL server from your distribution's package manager |
 
@@ -23,4 +23,4 @@ Please check the [wiki](https://github.com/SapphireMordred/Sapphire/wiki) for de
 
 * [Sapphire on YouTube](https://www.youtube.com/channel/UCJKYuovoGsq7PxSAfrNJKbw)
 
-Final Fantasy XIV © 2010-2017 SQUARE ENIX CO., LTD. All Rights Reserved. We are not affiliated with SQUARE ENIX CO., LTD. in any way.
+Final Fantasy XIV © 2010-2018 SQUARE ENIX CO., LTD. All Rights Reserved. We are not affiliated with SQUARE ENIX CO., LTD. in any way.

--- a/src/servers/Scripts/opening/OpeningGridania.cpp
+++ b/src/servers/Scripts/opening/OpeningGridania.cpp
@@ -1,3 +1,4 @@
+#include <Common.h>
 #include <Actor/Player.h>
 #include <ScriptObject.h>
 
@@ -29,6 +30,29 @@ private:
    {
       auto callback = [this]( Entity::Player& player, const Event::SceneResult& result )
       {
+         auto questionAnswer = result.param2;
+         int16_t rSlotId;
+
+         switch( questionAnswer )
+         {
+            case 1:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4423, 1, false, true ); break;
+            case 2:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4424, 1, false, true ); break;
+            case 3:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4425, 1, false, true ); break;
+            case 4:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4426, 1, false, true ); break;
+            default: rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4426, 1, false, true ); break;
+         }
+
+         if( rSlotId != -1 )
+         {
+            auto pItem = player.getItemAt( Common::InventoryType::ArmoryRing, rSlotId );
+
+            player.sendDebug( std::to_string( rSlotId ) );
+
+            if( pItem )
+               player.equipItem( Common::EquipSlot::Ring2, pItem, true );
+               
+         }
+
          player.setOpeningSequence( 1 );
          Scene00001( player );
       };

--- a/src/servers/Scripts/opening/OpeningGridania.cpp
+++ b/src/servers/Scripts/opening/OpeningGridania.cpp
@@ -1,4 +1,3 @@
-#include <Common.h>
 #include <Actor/Player.h>
 #include <ScriptObject.h>
 

--- a/src/servers/Scripts/opening/OpeningLimsa.cpp
+++ b/src/servers/Scripts/opening/OpeningLimsa.cpp
@@ -44,6 +44,29 @@ private:
    {
       auto callback = [this]( Entity::Player& player, const Event::SceneResult& result )
       {
+         auto questionAnswer = result.param2;
+         int16_t rSlotId;
+
+         switch( questionAnswer )
+         {
+            case 1:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4423, 1, false, true ); break;
+            case 2:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4424, 1, false, true ); break;
+            case 3:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4425, 1, false, true ); break;
+            case 4:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4426, 1, false, true ); break;
+            default: rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4426, 1, false, true ); break;
+         }
+
+         if( rSlotId != -1 )
+         {
+            auto pItem = player.getItemAt( Common::InventoryType::ArmoryRing, rSlotId );
+
+            player.sendDebug( std::to_string( rSlotId ) );
+
+            if( pItem )
+               player.equipItem( Common::EquipSlot::Ring2, pItem, true );
+
+         }
+
          player.setOpeningSequence( 1 );
          Scene00001( player );
       };

--- a/src/servers/Scripts/opening/OpeningUldah.cpp
+++ b/src/servers/Scripts/opening/OpeningUldah.cpp
@@ -30,6 +30,29 @@ private:
    {
       auto callback = [this]( Entity::Player& player, const Event::SceneResult& result )
       {
+         auto questionAnswer = result.param2;
+         int16_t rSlotId;
+
+         switch( questionAnswer )
+         {
+            case 1:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4423, 1, false, true ); break;
+            case 2:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4424, 1, false, true ); break;
+            case 3:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4425, 1, false, true ); break;
+            case 4:  rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4426, 1, false, true ); break;
+            default: rSlotId = player.addItem( Common::InventoryType::ArmoryRing, -1, 4426, 1, false, true ); break;
+         }
+
+         if( rSlotId != -1 )
+         {
+            auto pItem = player.getItemAt( Common::InventoryType::ArmoryRing, rSlotId );
+
+            player.sendDebug( std::to_string( rSlotId ) );
+
+            if( pItem )
+               player.equipItem( Common::EquipSlot::Ring2, pItem, true );
+
+         }
+
          player.setOpeningSequence( 1 );
          Scene00001( player );
       };

--- a/src/servers/sapphire_api/PlayerMinimal.cpp
+++ b/src/servers/sapphire_api/PlayerMinimal.cpp
@@ -339,28 +339,49 @@ namespace Core {
       insertDbGlobalItem( legs, legsUid );
       insertDbGlobalItem( feet, feetUid );
 
+      // Universal accessories
+
+      uint64_t neckUid = getNextUId64();
+      uint64_t earUid = getNextUId64();
+      uint64_t wristUid = getNextUId64();
+      uint64_t ringUid = getNextUId64();
+      
+
+      insertDbGlobalItem( 15130, neckUid );
+      insertDbGlobalItem( 15131, earUid );
+      insertDbGlobalItem( 15132, wristUid );
+      insertDbGlobalItem( 15133, ringUid );
+
       g_charaDb.execute( "INSERT INTO charaitemgearset (storageId, CharacterId, "
          "container_" + std::to_string( EquipSlot::MainHand ) + ", "
          "container_" + std::to_string( EquipSlot::Body ) + ", "
          "container_" + std::to_string( EquipSlot::Hands ) + ", "
          "container_" + std::to_string( EquipSlot::Legs ) + ", "
          "container_" + std::to_string( EquipSlot::Feet ) + ", "
+         "container_" + std::to_string( EquipSlot::Neck ) + ", "
+         "container_" + std::to_string( EquipSlot::Ear ) + ", "
+         "container_" + std::to_string( EquipSlot::Wrist ) + ", "
+         "container_" + std::to_string( EquipSlot::Ring1 ) + ", "
          "UPDATE_DATE ) "
          "VALUES ( " + std::to_string( InventoryType::GearSet0 ) + ", " + std::to_string( m_id ) + ", " +
          std::to_string( uniqueId ) + ", " +
          std::to_string( bodyUid ) + ", " +
          std::to_string( handsUid ) + ", " +
          std::to_string( legsUid ) + ", " +
-         std::to_string( feetUid ) + ", NOW());" );
+         std::to_string( feetUid ) + ", " +
+         std::to_string( neckUid ) + ", " + 
+         std::to_string( earUid ) + ", " + 
+         std::to_string( wristUid ) + ", " + 
+         std::to_string( ringUid ) + ", NOW());" );
 
    }
 
-   void PlayerMinimal::insertDbGlobalItem( uint32_t weaponId, uint64_t uniqueId ) const
+   void PlayerMinimal::insertDbGlobalItem( uint32_t itemId, uint64_t uniqueId ) const
    {
       auto stmtItemGlobal = g_charaDb.getPreparedStatement( Db::CHARA_ITEMGLOBAL_INS );
       stmtItemGlobal->setInt( 1, m_id );
       stmtItemGlobal->setInt64( 2, uniqueId );
-      stmtItemGlobal->setInt( 3, weaponId );
+      stmtItemGlobal->setInt( 3, itemId );
       g_charaDb.directExecute( stmtItemGlobal );
    }
 

--- a/src/servers/sapphire_api/PlayerMinimal.h
+++ b/src/servers/sapphire_api/PlayerMinimal.h
@@ -191,7 +191,7 @@ namespace Core {
 
       char m_name[34];
 
-      void insertDbGlobalItem( uint32_t weaponId, uint64_t uniqueId ) const;
+      void insertDbGlobalItem( uint32_t itemId, uint64_t uniqueId ) const;
    };
 
 }


### PR DESCRIPTION
## Opening + char create items ##
Creating a new character will replicate retail in adding accessories.
Additionally, it'll add the proper item from the choice in the cutscene.

Currently there's an issue with the item handling process. As such the ring gained from the cutscene will not be equipped automatically. This is to be fixed on dependency of item handling