### PR TITLE
SharedEstateSettings Ops Added / Level Up Fixed

### DIFF
--- a/src/common/Network/CommonActorControl.h
+++ b/src/common/Network/CommonActorControl.h
@@ -287,6 +287,8 @@ enum ClientTriggerType
   AchievementCritReq = 0x3E8,
   AchievementList = 0x3E9,
 
+  RequestSharedEstateSettings = 0x46F,
+
   CompanionAction = 0x6A4,
   CompanionSetBarding = 0x6A5,
   CompanionActionUnlock = 0x6A6,

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -187,6 +187,8 @@ enum ServerZoneIpcType :
   WardHousingPermission = 0x0229, // updated 4.4
   WardYardInfo = 0x022B, // updated 4.4
 
+  SharedEstateSettingsResponse = 0x023C, // updated 4.4
+
   DuelChallenge = 0x0277, // 4.2; this is responsible for opening the ui
   PerformNote = 0x0286, // updated 4.3
 
@@ -279,6 +281,8 @@ enum ClientZoneIpcType :
 
   LinkshellEventHandler = 0x0150, // updated 4.1 ??
   LinkshellEventHandler1 = 0x0151, // updated 4.1 ??
+
+  SetSharedEstateSettings = 0x0177, // updated 4.4
 
   PerformNoteHandler = 0x029B, // updated 4.3
 

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -127,7 +127,7 @@ enum ServerZoneIpcType :
   ObjectSpawn = 0x0179, // updated 4.4
   ObjectDespawn = 0x017A, // updated 4.4
 
-  SetLevelSync = 0x017B, // updated 4.4
+  UpdateClassInfo = 0x017B, // updated 4.4
   SilentSetClassJob = 0x017C, // updated 4.4 - seems to be the case, not sure if it's actually used for anything
 
   InitUI = 0x017D, // updated 4.4
@@ -138,7 +138,7 @@ enum ServerZoneIpcType :
   ModelEquip = 0x0182, // updated 4.4
   Examine = 0x0183, // updated 4.4
   CharaNameReq = 0x0185, // updated 4.4
-  UpdateClassInfo = 0x0186, // updated 4.4
+  SetLevelSync = 0x0186, // not updated for 4.4, not sure what it is anymore
 
   ItemInfo = 0x018C, // updated 4.4
   ContainerInfo = 0x018D, // updated 4.4

--- a/src/common/Network/PacketDef/Zone/ClientZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ClientZoneDef.h
@@ -183,6 +183,20 @@ struct FFXIVIpcInventoryModifyHandler :
   /* 0028 */ uint32_t splitCount;
 };
 
+struct FFXIVIpcSetSharedEstateSettings :
+  FFXIVIpcBasePacket< SetSharedEstateSettings >
+{
+  /* 0000 */ uint64_t char1ContentId;
+  /* 0008 */ uint64_t char2ContentId;
+  /* 0010 */ uint64_t char3ContentId;
+  /* 0018 */ uint8_t char1Permissions;
+  /* 0019 */ char padding1[0x7];
+  /* 0020 */ uint8_t char2Permissions;
+  /* 0021 */ char padding2[0x7];
+  /* 0028 */ uint8_t char3Permissions;
+  /* 0029 */ char padding3[0x7];
+};
+
 }
 }
 }

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1594,7 +1594,7 @@ struct FFXIVIpcWardYardInfo :
 
 /**
 * Structural representation of the packet sent by the server
-* to show the shared estate settings
+* to show the current shared estate settings
 */
 struct FFXIVIpcActorFreeSpawn :
   FFXIVIpcBasePacket< SharedEstateSettingsResponse >

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1592,6 +1592,27 @@ struct FFXIVIpcWardYardInfo :
   } object[100];
 };
 
+/**
+* Structural representation of the packet sent by the server
+* to show the shared estate settings
+*/
+struct FFXIVIpcActorFreeSpawn :
+  FFXIVIpcBasePacket< SharedEstateSettingsResponse >
+{
+  uint64_t char1ContentId;
+  uint8_t char1Permissions;
+  char char1Name[0x20];
+  char padding1[0x7];
+  uint64_t char2ContentId;
+  uint8_t char2Permissions;
+  char char2Name[0x20];
+  char padding2[0x7];
+  uint64_t char3ContentId;
+  uint8_t char3Permissions;
+  char char3Name[0x20];
+  char padding3[0x7];
+};
+
 struct FFXIVIpcMSQTrackerProgress :
   FFXIVIpcBasePacket< MSQTrackerProgress >
 {

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1596,7 +1596,7 @@ struct FFXIVIpcWardYardInfo :
 * Structural representation of the packet sent by the server
 * to show the current shared estate settings
 */
-struct FFXIVIpcActorFreeSpawn :
+struct FFXIVIpcSharedEstateSettingsResponse :
   FFXIVIpcBasePacket< SharedEstateSettingsResponse >
 {
   struct playerEntry {

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1599,18 +1599,12 @@ struct FFXIVIpcWardYardInfo :
 struct FFXIVIpcActorFreeSpawn :
   FFXIVIpcBasePacket< SharedEstateSettingsResponse >
 {
-  uint64_t char1ContentId;
-  uint8_t char1Permissions;
-  char char1Name[0x20];
-  char padding1[0x7];
-  uint64_t char2ContentId;
-  uint8_t char2Permissions;
-  char char2Name[0x20];
-  char padding2[0x7];
-  uint64_t char3ContentId;
-  uint8_t char3Permissions;
-  char char3Name[0x20];
-  char padding3[0x7];
+  struct playerEntry {
+    uint64_t contentId;
+    uint8_t permissions;
+    char name[0x20];
+    char padding[0x7];
+  } entry[3];
 };
 
 struct FFXIVIpcMSQTrackerProgress :


### PR DESCRIPTION
This PR adds more Opcodes, Structs and fixes the level up bug

- Added RequestSharedEstateSettings ClientTrigger
- Added SharedEstateSettingsResponse Opcode and Struct
- Added SetSharedEstateSettings Opcode and Struct
- Changed Opcode for UpdateClassInfo/SetLevelSync to fix the level up bug