### PR TITLE
update boost version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Sapphire requires the following software:
 | *Name* | *Windows* | *Linux* |
 | ------ | --------- | ------- |
 | CMake 3.0.2+ and C++14 capable compiler | [Visual Studio 2017](https://www.visualstudio.com/) | `gcc 4.9` and `g++ 4.9` or newer |
-| Boost 1.63.0 | [Win32 precompiled binaries](https://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-14.0-32.exe/download) | Boost libraries from your distribution's package manager |
-| MySQL Server 5.7 | [Official Site](https://dev.mysql.com/downloads/mysql/) | MySQL server from your distribution's package manager |
+| Boost 1.65.0 | [Win32 precompiled binaries](https://sourceforge.net/projects/boost/files/boost-binaries/1.65.0/boost_1_65_0-msvc-14.1-32.exe/download) | Boost libraries from your distribution's package manager |
+| MySQL Server 5.7 or MariaDB equivalent | [Official Site](https://dev.mysql.com/downloads/mysql/) | MySQL server from your distribution's package manager |
 
 Please check the [wiki](https://github.com/SapphireMordred/Sapphire/wiki) for detailed installation/build instructions for your OS.
 


### PR DESCRIPTION
vs2017 compiler/linker is at v14.1 now - boost 1.63 doesn't have builds for v14.1