### PR TITLE
Fix the packet data size being computed incorrectly.

### DIFF
--- a/src/common/Network/GamePacketParser.cpp
+++ b/src/common/Network/GamePacketParser.cpp
@@ -95,7 +95,7 @@ PacketParseResult Network::Packets::getPacket( const std::vector< uint8_t >& buf
     return Malformed;
 
   const auto dataOffset = offset + sizeof( struct FFXIVARR_PACKET_SEGMENT_HEADER );
-  const auto dataSize = packet.segHdr.size;
+  const auto dataSize = packet.segHdr.size - sizeof( struct FFXIVARR_PACKET_SEGMENT_HEADER );
 
   // Check if the packet is complete
   if( dataOffset + dataSize > buffer.size() )
@@ -125,6 +125,10 @@ bool Network::Packets::checkSegmentHeader( const FFXIVARR_PACKET_SEGMENT_HEADER&
 {
   // Max size of individual message is capped at 256KB for now.
   if( header.size > 256 * 1024 )
+    return false;
+
+  // The size of the segment header itself is included in the packet size.
+  if( header.size < sizeof( struct FFXIVARR_PACKET_SEGMENT_HEADER ) )
     return false;
 
   return true;


### PR DESCRIPTION
The new check introduced in #1000 for incomplete packets had 'false positives' because the packet data size erroneously included the header size. This cause massive delays while loading the character and potential disconnects.