### PR TITLE
Enable unity build for scripts

### DIFF
--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -15,6 +15,14 @@ if( WIN32 )
     set( CMAKE_LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${SCRIPT_LIB_DIR}" )
 endif()
 
+# Enable unity builds if not explicitly enabled/disabled
+if(NOT DEFINED CMAKE_UNITY_BUILD)
+    message(STATUS "Enabled unity builds for scripts (-DCMAKE_UNITY_BUILD=OFF to disable)")
+    set(CMAKE_UNITY_BUILD ON)
+    set(CMAKE_UNITY_BUILD_BATCH_SIZE 16)
+    set(SCRIPT_UNITY_BUILD ON)
+endif()
+
 file(GLOB children "${CMAKE_CURRENT_SOURCE_DIR}/*" )
 foreach(_scriptDir ${children})
     get_filename_component(_name "${_scriptDir}" NAME_WE)
@@ -78,3 +86,7 @@ foreach(_scriptDir ${children})
         unset(ScriptNames)
     endif()
 endforeach()
+
+if(SCRIPT_UNITY_BUILD)
+    set(CMAKE_UNITY_BUILD OFF)
+endif()


### PR DESCRIPTION
This is a quick win that improves build times by about 2x in CI:

<img width="1317" height="610" alt="image" src="https://github.com/user-attachments/assets/df916d1d-59b5-4136-ac4a-a84cbe594da5" />

Potential downsides:
- Editing a single script file will rebuild 16 files at once
- More memory will be consumed during compilation
- Defining the same name in global scope (for example `static int x;`) of multiple files will cause a build error
