### PR TITLE
Gracefully error when failing to start server

### DIFF
--- a/src/common/Network/Acceptor.cpp
+++ b/src/common/Network/Acceptor.cpp
@@ -87,23 +87,14 @@ void Network::Acceptor::accept( ConnectionPtr connection )
 
 void Network::Acceptor::listen( const std::string& host, const uint16_t& port )
 {
-  try
-  {
-    asio::ip::tcp::resolver resolver( m_hive->getService() );
-    asio::ip::tcp::resolver::query query( host, std::to_string( port ) );
-    asio::ip::tcp::endpoint endpoint = *resolver.resolve( query );
+  asio::ip::tcp::resolver resolver( m_hive->getService() );
+  asio::ip::tcp::resolver::query query( host, std::to_string( port ) );
+  asio::ip::tcp::endpoint endpoint = *resolver.resolve( query );
 
-    m_acceptor.open( endpoint.protocol() );
-    m_acceptor.set_option( asio::ip::tcp::acceptor::reuse_address( false ) );
-    m_acceptor.bind( endpoint );
-    m_acceptor.listen( asio::socket_base::max_connections );
-  }
-  catch( ... )
-  {
-    // this should not happen
-    assert( true );
-  }
-
+  m_acceptor.open( endpoint.protocol() );
+  m_acceptor.set_option( asio::ip::tcp::acceptor::reuse_address( false ) );
+  m_acceptor.bind( endpoint );
+  m_acceptor.listen( asio::socket_base::max_connections );
 }
 
 Network::HivePtr Network::Acceptor::getHive()

--- a/src/common/Network/Connection.h
+++ b/src/common/Network/Connection.h
@@ -140,18 +140,11 @@ namespace Sapphire::Network
   template< class T >
   std::shared_ptr< T > addServerToHive( const std::string& listenIp, uint32_t port, HivePtr pHive )
   {
-    try
-    {
-      AcceptorPtr acceptor( new Acceptor( pHive ) );
-      acceptor->listen( listenIp, port );
-      std::shared_ptr< T > connection( new T( pHive, acceptor ) );
-      acceptor->accept( connection );
-      return connection;
-    }
-    catch( std::runtime_error e )
-    {
-      throw;
-    }
+    AcceptorPtr acceptor( new Acceptor( pHive ) );
+    acceptor->listen( listenIp, port );
+    std::shared_ptr< T > connection( new T( pHive, acceptor ) );
+    acceptor->accept( connection );
+    return connection;
   }
 
 }

--- a/src/lobby/ServerLobby.cpp
+++ b/src/lobby/ServerLobby.cpp
@@ -64,7 +64,15 @@ namespace Sapphire::Lobby
     Logger::setLogLevel( m_config.global.general.logLevel );
 
     auto hive = Network::make_Hive();
-    Network::addServerToHive< GameConnection >( m_ip, m_port, hive );
+
+    try
+    {
+      Network::addServerToHive< GameConnection >( m_ip, m_port, hive );
+    } catch( std::exception& e )
+    {
+      Logger::fatal( "Error starting server: {0}", e.what() );
+      return;
+    }
 
     Logger::info( "Lobby server running on {0}:{1}", m_ip, m_port );
 

--- a/src/world/WorldServer.cpp
+++ b/src/world/WorldServer.cpp
@@ -323,7 +323,14 @@ void WorldServer::run( int32_t argc, char* argv[] )
 
 
   Network::HivePtr hive( new Network::Hive() );
-  Network::addServerToHive< Network::GameConnection >( m_ip, m_port, hive );
+  try
+  {
+    Network::addServerToHive< Network::GameConnection >( m_ip, m_port, hive );
+  } catch( std::exception& e )
+  {
+    Logger::fatal( "Error starting server: {0}", e.what() );
+    return;
+  }
 
   std::vector< std::thread > thread_list;
   thread_list.emplace_back( std::thread( std::bind( &Network::Hive::run, hive.get() ) ) );


### PR DESCRIPTION
<img width="979" height="544" alt="image" src="https://github.com/user-attachments/assets/bfa31e78-11d6-4f9b-a91b-477f12afdf68" />

If the port is in use already the server will now gracefully fail with an error message. The error is duplicated, but that is a bug in asio.